### PR TITLE
Install gnu-tar if missing in MacOS

### DIFF
--- a/roles/local-init/tasks/download_dependency.yml
+++ b/roles/local-init/tasks/download_dependency.yml
@@ -1,0 +1,7 @@
+---
+- name: "Install gnu-tar in MacOS"
+  ansible.builtin.package:
+    name: gnu-tar
+    state: present
+  when:
+  - ansible_system == "Darwin"

--- a/roles/local-init/tasks/download_package.yml
+++ b/roles/local-init/tasks/download_package.yml
@@ -22,13 +22,6 @@
   - ansible_system == "Darwin"
   - check_package_file.stat.exists == False
 
-- name: "{{ package_name }}: Install gnu-tar in MacOS"
-  ansible.builtin.package:
-    name: gnu-tar
-    state: present
-  when:
-  - ansible_system == "Darwin"
-
 - name: "{{ package_name }}: Unarchive Package"
   unarchive:
     src: "{{ download_result.dest }}"

--- a/roles/local-init/tasks/main.yml
+++ b/roles/local-init/tasks/main.yml
@@ -7,6 +7,11 @@
   tags:
   - localhost
 
+- name: Start to download dependencies
+  include_tasks: download_dependency.yml
+  tags:
+  - localhost
+
 - name: Start to download a package
   include_tasks: download_package.yml
   loop:


### PR DESCRIPTION
Ansible unarchive module requires gnu-tar, and it is specified as requirements in the README.

However, adding task to install gnu-tar in MacOS would help users.

This PR follows-up #5.