### PR TITLE
replace node variable with ctx

### DIFF
--- a/roles/local-init/tasks/genesis.yml
+++ b/roles/local-init/tasks/genesis.yml
@@ -8,7 +8,7 @@
 
 - name: "Generate {{ ctx.type }} data & genesis.json by Homi"
   shell: |
-    {{ homi_bin }} setup local {{ homi_default_options }} --test-num {{ homi_test_account_num }} --cn-num {{ node.num }} --chainID {{ klaytn_network_id }} --network-id {{ klaytn_network_id }} -o {{ homi_output_dir }}/{{ node.type }}
+    {{ homi_bin }} setup local {{ homi_default_options }} --test-num {{ homi_test_account_num }} --cn-num {{ ctx.num }} --chainID {{ klaytn_network_id }} --network-id {{ klaytn_network_id }} -o {{ homi_output_dir }}/{{ ctx.type }}
   tags:
   - localhost
   when:


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed or improved. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue) While deploying Klaytn services by Ansible, below task was failed due to the variable 'node'.
`TASK [local-init : Generate cn data & genesis.json by Homi] *****************************************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'node' is undefined\n\nThe error appears to be in '/Users/krust/github/klaytn/klayspray/roles/local-init/tasks/genesis.yml': line 9, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: \"Generate {{ ctx.type }} data & genesis.json by Homi\"\n  ^ here\nWe could be wrong, but this one looks like it might be an issue with\nmissing quotes. Always quote template expression brackets when they\nstart a value. For instance:\n\n    with_items:\n      - {{ foo }}\n\nShould be written as:\n\n    with_items:\n      - \"{{ foo }}\"\n"}`


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* Public Cloud: 
* OS version:
* Klaytn version:
* Ansible version:
* Terraform version:

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
