### PR TITLE
Support existing key pair and vpc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,7 @@ cache
 terraform.tfstate*
 .terraform*
 *.pem
+.idea
 .DS_Store
 roles/klaytn_node/*
+inventory/private-layer1/inventory.ini

--- a/terraform/gcp/modules/keypair/main.tf
+++ b/terraform/gcp/modules/keypair/main.tf
@@ -1,18 +1,32 @@
 resource "tls_private_key" "this" {
-  count = var.create_gcp_key_pair == true ? 1 : 0
+  count = var.create_gcp_key_pair ? 1 : 0
 
   algorithm = "RSA"
   rsa_bits  = 2048
 }
 
 resource "local_sensitive_file" "this" {
-  count = var.create_gcp_key_pair == true ? 1 : 0
+  count = var.create_gcp_key_pair ? 1 : 0
 
-  content         = tls_private_key.this[0].private_key_openssh
+  content         = tls_private_key.this[0].private_key_pem
   filename        = var.ssh_private_key_path
   file_permission = "0400"
 }
 
+# Extract public key from generated private key
 data "tls_public_key" "this" {
+  count = var.create_gcp_key_pair ? 1 : 0
   private_key_pem = tls_private_key.this[0].private_key_pem
+}
+
+# Read existing public key when not creating a new key pair
+data "local_file" "existing_public_key" {
+  count    = var.create_gcp_key_pair ? 0 : 1
+  filename = var.ssh_existing_public_key_path
+}
+
+locals {
+  # Use the appropriate key and public key based on configuration
+  private_key_path = var.create_gcp_key_pair ? var.ssh_private_key_path : var.ssh_existing_private_key_path
+  public_key = var.create_gcp_key_pair ? data.tls_public_key.this[0].public_key_openssh : data.local_file.existing_public_key[0].content
 }

--- a/terraform/gcp/modules/keypair/outputs.tf
+++ b/terraform/gcp/modules/keypair/outputs.tf
@@ -1,11 +1,11 @@
-output "ssh_private_key" {
-  value = try(tls_private_key.this[0].private_key_openssh, null)
+output "key_pair_name" {
+  value = var.name
 }
 
 output "ssh_public_key" {
-  value = try(data.tls_public_key.this.public_key_openssh, null)
+  value = local.public_key
 }
 
 output "ssh_private_key_path" {
-  value = try(local_sensitive_file.this[0].filename, null)
+  value = local.private_key_path
 }

--- a/terraform/gcp/modules/keypair/variables.tf
+++ b/terraform/gcp/modules/keypair/variables.tf
@@ -11,11 +11,24 @@ variable "tags" {
 
 variable "create_gcp_key_pair" {
   type        = bool
-  description = "Flag to create gcp key pair or not "
+  description = "Controls if GCP key pair should be created"
   default     = true
 }
 
 variable "ssh_private_key_path" {
   type        = string
-  description = "SSH private key path to save"
+  description = "Path where the generated private key will be saved when create_gcp_key_pair is true"
+  default     = ""
+}
+
+variable "ssh_existing_private_key_path" {
+  type        = string
+  description = "Path where the private key is saved. It is only used when create_gcp_key_pair is false"
+  default     = ""
+}
+
+variable "ssh_existing_public_key_path" {
+  type        = string
+  description = "Path where the public key is saved. It is only used when create_gcp_key_pair is false"
+  default     = ""
 }

--- a/terraform/gcp/modules/klaytn-node/data.tf
+++ b/terraform/gcp/modules/klaytn-node/data.tf
@@ -1,6 +1,3 @@
-data "google_compute_zones" "this" {
-}
-
 data "google_compute_image" "this" {
   family  = "centos-stream-9"
   project = "centos-cloud"

--- a/terraform/gcp/modules/klaytn-node/main.tf
+++ b/terraform/gcp/modules/klaytn-node/main.tf
@@ -25,7 +25,8 @@ resource "google_compute_instance" "this" {
       for_each = var.use_public_ip == true ? [1] : []
 
       content {
-        nat_ip = google_compute_address.this[0].address
+        nat_ip       = google_compute_address.this[0].address
+        network_tier = var.network_tier
       }
     }
   }
@@ -48,5 +49,7 @@ resource "google_compute_disk" "this" {
 resource "google_compute_address" "this" {
   count = var.use_public_ip ? 1 : 0
 
-  name = format("%s-ip", var.name)
+  name         = format("%s-ip", var.name)
+  region       = var.region != null ? var.region : "asia-southeast1"
+  network_tier = var.network_tier
 }

--- a/terraform/gcp/modules/klaytn-node/main.tf
+++ b/terraform/gcp/modules/klaytn-node/main.tf
@@ -5,7 +5,7 @@ resource "google_compute_instance" "this" {
 
   boot_disk {
     initialize_params {
-      image = lookup(var.boot_disk, "image_id", "centos-7")
+      image = lookup(var.boot_disk, "image_id", data.google_compute_image.this.family)
       size  = lookup(var.boot_disk, "boot_disk_size", 20)
     }
   }
@@ -50,4 +50,3 @@ resource "google_compute_address" "this" {
 
   name = format("%s-ip", var.name)
 }
-

--- a/terraform/gcp/modules/klaytn-node/variables.tf
+++ b/terraform/gcp/modules/klaytn-node/variables.tf
@@ -48,6 +48,18 @@ variable "project" {
   default     = null
 }
 
+variable "region" {
+  type        = string
+  description = "GCP region for resources"
+  default     = null
+}
+
+variable "network_tier" {
+  type        = string
+  description = "Network tier for external IP addresses (PREMIUM or STANDARD)"
+  default     = "STANDARD"
+}
+
 variable "tags" {
   type        = list(any)
   description = "Tag list"

--- a/terraform/gcp/modules/private-layer1/firewall_rules.tf
+++ b/terraform/gcp/modules/private-layer1/firewall_rules.tf
@@ -76,26 +76,26 @@ locals {
 }
 
 module "firewall_rules" {
-  for_each = { for v in local.firewall_rules : v.name => v }
+  count = length(var.network_tags) > 0 ? 0 : length(local.firewall_rules)
 
   source       = "terraform-google-modules/network/google//modules/firewall-rules"
   project_id   = var.project_id
   network_name = var.network
 
   rules = [{
-    name                    = try(each.value.name, "rule")
-    description             = try(each.value.description, null)
-    direction               = try(each.value.direction, "INGRESS") # INGRESS OR EGRESS
-    priority                = try(each.value.priority, null)
-    ranges                  = try(each.value.ranges, null) # []
-    source_tags             = try(each.value.source_tags, null)
-    source_service_accounts = try(each.value.source_service_accounts, null)
-    target_tags             = try(each.value.target_tags, null)
-    target_service_accounts = try(each.value.target_service_accounts, null)
+    name                    = try(local.firewall_rules[count.index].name, "rule")
+    description             = try(local.firewall_rules[count.index].description, null)
+    direction               = try(local.firewall_rules[count.index].direction, "INGRESS") # INGRESS OR EGRESS
+    priority                = try(local.firewall_rules[count.index].priority, null)
+    ranges                  = try(local.firewall_rules[count.index].ranges, null) # []
+    source_tags             = try(local.firewall_rules[count.index].source_tags, null)
+    source_service_accounts = try(local.firewall_rules[count.index].source_service_accounts, null)
+    target_tags             = try(local.firewall_rules[count.index].target_tags, null)
+    target_service_accounts = try(local.firewall_rules[count.index].target_service_accounts, null)
 
     allow = [{
-      protocol = try(each.value.allow.protocol, "tcp")
-      ports    = try(each.value.allow.ports, null) # []
+      protocol = try(local.firewall_rules[count.index].allow.protocol, "tcp")
+      ports    = try(local.firewall_rules[count.index].allow.ports, null) # []
     }]
 
     deny = []

--- a/terraform/gcp/modules/private-layer1/firewall_rules.tf
+++ b/terraform/gcp/modules/private-layer1/firewall_rules.tf
@@ -1,7 +1,7 @@
 locals {
   firewall_rules = [
     {
-      name        = "ssh"
+      name        = "kaiaspray-ssh"
       direction   = "INGRESS"
       ranges      = var.ssh_client_ips
       target_tags = ["klayspray"]
@@ -11,7 +11,7 @@ locals {
       }
     },
     {
-      name        = "rpc-tcp"
+      name        = "kaiaspray-rpc-tcp"
       direction   = "INGRESS"
       ranges      = ["0.0.0.0/0"]
       source_tags = ["cn", "pn", "en"]
@@ -22,7 +22,7 @@ locals {
       }
     },
     {
-      name        = "rpc-udp"
+      name        = "kaiaspray-rpc-udp"
       direction   = "INGRESS"
       ranges      = ["0.0.0.0/0"]
       source_tags = ["cn", "pn", "en"]
@@ -33,7 +33,7 @@ locals {
       }
     },
     {
-      name        = "monitor-internal"
+      name        = "kaiaspray-monitor-internal"
       direction   = "INGRESS"
       source_tags = ["monitor"]
       target_tags = ["cn", "pn", "en"]
@@ -43,7 +43,7 @@ locals {
       }
     },
     {
-      name        = "monitor-external"
+      name        = "kaiaspray-monitor-external"
       direction   = "INGRESS"
       ranges      = ["0.0.0.0/0"]
       target_tags = ["monitor"]
@@ -53,7 +53,7 @@ locals {
       }
     },
     {
-      name        = "egress-tcp"
+      name        = "kaiaspray-egress-tcp"
       direction   = "EGRESS"
       ranges      = ["0.0.0.0/0"]
       target_tags = ["klayspray"]
@@ -63,7 +63,7 @@ locals {
       }
     },
     {
-      name        = "egress-udp"
+      name        = "kaiaspray-egress-udp"
       direction   = "EGRESS"
       ranges      = ["0.0.0.0/0"]
       target_tags = ["klayspray"]

--- a/terraform/gcp/modules/private-layer1/main.tf
+++ b/terraform/gcp/modules/private-layer1/main.tf
@@ -9,6 +9,8 @@ module "cn" {
   subnetwork    = var.subnetwork
   zone          = var.zone_list[count.index % length(var.zone_list)]
   use_public_ip = true
+  region        = var.gcp_region
+  network_tier  = var.network_tier
 
   boot_disk = {
     image_id       = var.boot_image_id
@@ -22,7 +24,7 @@ module "cn" {
   #   size = 100
   # }
 
-  tags = ["klayspray", "cn"]
+  tags = length(var.network_tags) > 0 ? concat(var.network_tags, ["klayspray", "cn"]) : ["klayspray", "cn"]
 
   metadata = merge(var.metadata, {
     Name = format("%s-cn-%d", var.name, count.index + 1)
@@ -40,6 +42,8 @@ module "pn" {
   subnetwork    = var.subnetwork
   zone          = var.zone_list[count.index % length(var.zone_list)]
   use_public_ip = true
+  region        = var.gcp_region
+  network_tier  = var.network_tier
 
   boot_disk = {
     image_id       = var.boot_image_id
@@ -53,7 +57,7 @@ module "pn" {
   #   size = 100
   # }
 
-  tags = ["klayspray", "pn"]
+  tags = length(var.network_tags) > 0 ? concat(var.network_tags, ["klayspray", "pn"]) : ["klayspray", "pn"]
 
   metadata = merge(var.metadata, {
     Name = format("%s-pn-%d", var.name, count.index + 1)
@@ -71,6 +75,8 @@ module "en" {
   subnetwork    = var.subnetwork
   zone          = var.zone_list[count.index % length(var.zone_list)]
   use_public_ip = true
+  region        = var.gcp_region
+  network_tier  = var.network_tier
 
   boot_disk = {
     image_id       = var.boot_image_id
@@ -84,7 +90,7 @@ module "en" {
   #   size = 100
   # }
 
-  tags = ["klayspray", "en"]
+  tags = length(var.network_tags) > 0 ? concat(var.network_tags, ["klayspray", "en"]) : ["klayspray", "en"]
 
   metadata = merge(var.metadata, {
     Name = format("%s-en-%d", var.name, count.index + 1)
@@ -100,6 +106,8 @@ module "monitor" {
   subnetwork    = var.subnetwork
   zone          = var.zone_list[0]
   use_public_ip = true
+  region        = var.gcp_region
+  network_tier  = var.network_tier
 
   boot_disk = {
     image_id       = var.boot_image_id
@@ -113,7 +121,7 @@ module "monitor" {
   #   size = 100
   # }
 
-  tags = ["klayspray", "monitor"]
+  tags = length(var.network_tags) > 0 ? var.network_tags : ["klayspray", "monitor"]
 
   metadata = merge(var.metadata, {
     Name = format("%s-monitor", var.name)

--- a/terraform/gcp/modules/private-layer1/variables.tf
+++ b/terraform/gcp/modules/private-layer1/variables.tf
@@ -66,3 +66,27 @@ variable "metadata" {
 variable "project_id" {
   type = string
 }
+
+variable "create_gcp_firewall_rules" {
+  description = "Flag to determine whether to create a GCP firewall rules."
+  type        = bool
+  default     = false  # Default to false; set to true to create the firewall rules
+}
+
+variable "network_tags" {
+  type        = list(string)
+  description = "List of network tags"
+  default     = []
+}
+
+variable "gcp_region" {
+  type        = string
+  description = "GCP region where all resources will be created"
+  default     = "asia-southeast1"
+}
+
+variable "network_tier" {
+  type        = string
+  description = "Network tier for external IP addresses (PREMIUM or STANDARD)"
+  default     = "PREMIUM"
+}

--- a/terraform/gcp/private-layer1/README.md
+++ b/terraform/gcp/private-layer1/README.md
@@ -1,18 +1,26 @@
 # Deploy Private Layer1 Network on GCP
 
-### 1. Deploy GCP resources
+### 0. Prepare GCP Credentials
 > :warning: Before running the following commands, please get GCP credentials using command below.
+Option1.
+```bash
+gcloud auth application-default login
+```
+Option2.
 ```bash
 export GOOGLE_APPLICATION_CREDENTIALS="<path-to-credential-json>"
 ```
 
+### 1. Deploy GCP resources
 Execute command belows to deploy resources via Terraform.
 ```bash
 $ git clone https://github.com/klaytn/klayspray.git
 $ cd klayspray
 $ export TF_OPTIONS="-chdir=terraform/gcp/private-layer1"
 $ terraform $TF_OPTIONS init
+$ terraform $TF_OPTIONS plan
 $ terraform $TF_OPTIONS apply -auto-approve
+$ terraform $TF_OPTIONS destroy -auto-approve
 ```
 
 terraform output will be shown like the below.
@@ -56,6 +64,43 @@ You can check two files in the root path of klayspray.
 1. gcp-private-ssh-key.pem: a file to use via SSH
 2. inventory/private-layer1/inventory.ini: a file storing Klaytn node connection information
 
+## SSH Key Management
+
+### Options for SSH Key Management
+
+1. **Generate a new SSH key pair**:
+   - Set `create_gcp_key_pair = true` in your terraform.tfvars file
+   - The private key will be automatically generated and saved to the path specified in the module
+   - The public key will be automatically extracted and added to instance metadata
+
+2. **Use an existing SSH key pair**:
+   - Set `create_gcp_key_pair = false` in your terraform.tfvars file
+   - Provide the path to your existing private key in `ssh_existing_private_key_path`
+   - Provide the path to your existing public key in `ssh_existing_public_key_path`
+
+### How to Extract Public Key from Private Key
+
+If you have an existing private key and need to extract the public key, you can use the following command:
+
+```bash
+# For OpenSSH format private keys
+ssh-keygen -y -f /path/to/private_key > /path/to/public_key.pub
+
+# For PEM format private keys
+ssh-keygen -y -f /path/to/private-key.pem > /path/to/public-key.pem
+```
+
+### Example terraform.tfvars
+
+```hcl
+# Option 1: Generate a new key pair
+create_gcp_key_pair = true
+
+# Option 2: Use existing key pair
+create_gcp_key_pair = false
+ssh_existing_private_key_path = "/path/to/private-key.pem"
+ssh_existing_public_key_path = "/path/to/public-key.pub"
+```
 
 ### 3. Execute Ansible playbook
 ```bash

--- a/terraform/gcp/private-layer1/ansible-inventory.tf
+++ b/terraform/gcp/private-layer1/ansible-inventory.tf
@@ -2,7 +2,7 @@ locals {
   ansible_inventory = templatefile(
     "${path.module}/templates/inventory.tftpl",
     {
-      ansible_ssh_private_key_file = try(module.keypair.ssh_private_key_path, "<change-me>")
+      ansible_ssh_private_key_file = module.keypair.ssh_private_key_path
       cn                           = try(module.layer1.cn, [])
       pn                           = try(module.layer1.pn, [])
       en                           = try(module.layer1.en, [])

--- a/terraform/gcp/private-layer1/common.tf
+++ b/terraform/gcp/private-layer1/common.tf
@@ -1,7 +1,9 @@
 module "keypair" {
   source = "../modules/keypair"
 
-  name                 = local.name
-  create_gcp_key_pair  = var.create_gcp_key_pair
-  ssh_private_key_path = format("%s/../../../gcp-private-ssh-key.pem", path.module)
+  name                       = local.name
+  create_gcp_key_pair        = var.create_gcp_key_pair
+  ssh_private_key_path       = format("%s/../../../gcp-private-ssh-key.pem", path.module)
+  ssh_existing_private_key_path = var.ssh_existing_private_key_path
+  ssh_existing_public_key_path  = var.ssh_existing_public_key_path
 }

--- a/terraform/gcp/private-layer1/data.tf
+++ b/terraform/gcp/private-layer1/data.tf
@@ -1,4 +1,5 @@
 data "google_compute_zones" "this" {
+  region = var.gcp_region
 }
 
 data "google_compute_image" "this" {

--- a/terraform/gcp/private-layer1/main.tf
+++ b/terraform/gcp/private-layer1/main.tf
@@ -3,9 +3,12 @@ module "layer1" {
 
   name       = local.name
   zone_list  = data.google_compute_zones.this.names
-  network    = module.vpc.network_self_link
-  subnetwork = one([for item in module.vpc.subnets_self_links : item if can(regex("public", item))])
+  network    = local.network_self_link
+  subnetwork = local.subnetwork_self_link
   project_id = var.project_id
+  network_tags = var.network_tags
+  gcp_region = var.gcp_region
+  network_tier = "STANDARD"  # Use STANDARD tier instead of PREMIUM
 
   boot_image_id  = data.google_compute_image.this.self_link
   ssh_client_ips = var.ssh_client_ips
@@ -18,6 +21,6 @@ module "layer1" {
   metadata = merge(
     var.metadata,
     local.default_metadata,
-    { ssh-keys = format("klay:%s klay", trimspace(module.keypair.ssh_public_key)) }
+    var.create_gcp_key_pair ? { ssh-keys = format("klay:%s klay", trimspace(module.keypair.ssh_public_key)) } : {}
   )
 }

--- a/terraform/gcp/private-layer1/outputs.tf
+++ b/terraform/gcp/private-layer1/outputs.tf
@@ -1,3 +1,17 @@
 output "layer1" {
-  value = module.layer1
+  value       = module.layer1
+  description = "Layer 1 module output"
+  sensitive   = true
+}
+
+output "project_region" {
+  value       = var.create_gcp_key_pair ? var.gcp_region : null
+  description = "GCP region"
+  sensitive   = false
+}
+
+output "project_id" {
+  value       = var.create_gcp_key_pair ? var.project_id : null
+  description = "GCP project ID"
+  sensitive   = false
 }

--- a/terraform/gcp/private-layer1/variables.tf
+++ b/terraform/gcp/private-layer1/variables.tf
@@ -47,8 +47,20 @@ variable "ssh_client_ips" {
 
 variable "create_gcp_key_pair" {
   type        = bool
-  description = "Flag to create gcp key pair or not "
+  description = "Controls if GCP key pair should be created"
   default     = true
+}
+
+variable "ssh_existing_private_key_path" {
+  type        = string
+  description = "Path where the private key is saved. It is only used when create_gcp_key_pair is false."
+  default     = ""
+}
+
+variable "ssh_existing_public_key_path" {
+  type        = string
+  description = "Path where the public key is saved. It is only used when create_gcp_key_pair is false."
+  default     = ""
 }
 
 variable "project" {

--- a/terraform/gcp/private-layer1/variables.tf
+++ b/terraform/gcp/private-layer1/variables.tf
@@ -47,7 +47,7 @@ variable "ssh_client_ips" {
 
 variable "create_gcp_key_pair" {
   type        = bool
-  description = "Controls if GCP key pair should be created"
+  description = "Flag to determine whether to create a GCP SSH key pair."
   default     = true
 }
 
@@ -64,9 +64,8 @@ variable "ssh_existing_public_key_path" {
 }
 
 variable "project" {
+  description = "The name of the project to create or use"
   type        = string
-  description = "GCP project name"
-  default     = null
 }
 
 variable "project_id" {
@@ -75,8 +74,36 @@ variable "project_id" {
   default     = null
 }
 
+variable "org_id" {
+  description = "The organization ID for the GCP project"
+  type        = string
+}
+
+variable "billing_account" {
+  description = "The billing account ID for the GCP project"
+  type        = string
+}
+
 variable "gcp_region" {
   type        = string
   description = "GCP region where all resources will be created"
   default     = "asia-northeast3"
+}
+
+variable "network" {
+  type        = string
+  description = "Network Name to be used"
+  default     = ""
+}
+
+variable "subnetwork" {
+  type        = string
+  description = "Subnet Name to be used"
+  default     = ""
+}
+
+variable "network_tags" {
+  description = "List of network tags to apply to the VPC."
+  type        = list(string)
+  default     = []
 }

--- a/terraform/gcp/private-layer1/vpc.tf
+++ b/terraform/gcp/private-layer1/vpc.tf
@@ -1,4 +1,6 @@
 module "vpc" {
+  count = var.network == "" ? 1 : 0 # create vpc only if network is not provided
+
   source = "terraform-google-modules/network/google"
 
   project_id   = var.project_id
@@ -27,4 +29,10 @@ module "vpc" {
       next_hop_internet = "true"
     },
   ]
+}
+
+# reference the VPC and Subnet
+locals {
+  network_self_link    = var.network != "" ? var.network : length(module.vpc) > 0 ? module.vpc[0].network_self_link : ""
+  subnetwork_self_link = var.subnetwork != "" ? var.subnetwork : length(module.vpc) > 0 ? [for item in module.vpc[0].subnets_self_links : item if can(regex("public", item))][0] : ""
 }


### PR DESCRIPTION
# Description

This PR adds a support of existing key pair and vpc. Tested with below terraform.tfvars.
```
project    = "klayspray"
project_id = "~~"
gcp_region = "asia-southeast1"

name           = "~~"
ssh_client_ips = ["0.0.0.0/0"]

network    = "~~"
subnetwork = "~~"
network_tags = ["ssh", "klaytn-metrics", "klaytn-rpc", "load-test", "grafana"]

create_gcp_key_pair = false
ssh_existing_private_key_path = "/path/to/private-key.pem"
ssh_existing_public_key_path  = "/path/to/public-key.pub"
...
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* Public Cloud: gcp
* OS verson: m4
* Klaytn version: default
* Ansible version: ansible [core 2.18.3]
* Terraform version: Terraform v1.10.5 on darwin_arm64

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
