### PR TITLE
Fix incorrect variable names in sample_properties.sh

### DIFF
--- a/local-deploy/sample_properties.sh
+++ b/local-deploy/sample_properties.sh
@@ -19,6 +19,6 @@ HOMI_ENKEYS=false
 
 # homi - some useful options
 HOMI_PATCH_ADDRESSBOOK=false # if you set true, the addressbook admin will be the cn1 nodekey.
-HOMI_REGISTRY=false # if you set true, the bls-registry mock will be registered automatically.
+HOMI_REGISTRY_MOCK=false # if you set true, the bls-registry mock will be registered automatically.
 HOMI_NUMOF_INITIAL_CN_NUM=0 # amount NUMOFCN, HOMI_NUMOF_INITIAL_CN_NUM will be addvalidate later.
 


### PR DESCRIPTION
# Description

This PR fixes the incorrect variable name in sample_properties.sh.
HOMI_REGISTRY_MOCK is used in 0_kaia_setup.sh, but in properties it is HOMI_REGISTRY.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* Public Cloud:
* OS verson:
* Kaia version:
* Ansible version:
* Terraform version:

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
