### PR TITLE
gcp: fix service_account option

### DIFF
--- a/terraform/gcp/modules/kaia-node/variables.tf
+++ b/terraform/gcp/modules/kaia-node/variables.tf
@@ -71,7 +71,10 @@ variable "metadata" {
 }
 
 variable "service_account" {
-  type        = map(any)
+  type = object({
+    email  = optional(string)
+    scopes = optional(list(string))
+  })
   description = "Service account to attach to the instance"
   default     = null
 }

--- a/terraform/gcp/modules/private-layer1/locals.tf
+++ b/terraform/gcp/modules/private-layer1/locals.tf
@@ -21,6 +21,7 @@ locals {
       boot_disk_size = try(lookup(var.cn_options, "options", {})[tostring(i)].boot_disk_size, lookup(var.cn_options, "boot_disk_size", local.defaults.boot_disk_size))
       compute_disk_size = try(lookup(var.cn_options, "options", {})[tostring(i)].compute_disk_size, lookup(var.cn_options, "compute_disk_size", local.defaults.compute_disk_size))
       snapshot_id = try(lookup(var.cn_options, "options", {})[tostring(i)].snapshot_id, lookup(var.cn_options, "snapshot_id", local.defaults.snapshot_id))
+      service_account = try(lookup(var.cn_options, "options", {})[tostring(i)].service_account, lookup(var.cn_options, "service_account", null))
     }
   ]
 
@@ -30,6 +31,7 @@ locals {
       boot_disk_size = try(lookup(var.pn_options, "options", {})[tostring(i)].boot_disk_size, lookup(var.pn_options, "boot_disk_size", local.defaults.boot_disk_size))
       compute_disk_size = try(lookup(var.pn_options, "options", {})[tostring(i)].compute_disk_size, lookup(var.pn_options, "compute_disk_size", local.defaults.compute_disk_size))
       snapshot_id = try(lookup(var.pn_options, "options", {})[tostring(i)].snapshot_id, lookup(var.pn_options, "snapshot_id", local.defaults.snapshot_id))
+      service_account = try(lookup(var.pn_options, "options", {})[tostring(i)].service_account, lookup(var.pn_options, "service_account", null))
     }
   ]
 
@@ -39,6 +41,7 @@ locals {
       boot_disk_size = try(lookup(var.en_options, "options", {})[tostring(i)].boot_disk_size, lookup(var.en_options, "boot_disk_size", local.defaults.boot_disk_size))
       compute_disk_size = try(lookup(var.en_options, "options", {})[tostring(i)].compute_disk_size, lookup(var.en_options, "compute_disk_size", local.defaults.compute_disk_size))
       snapshot_id = try(lookup(var.en_options, "options", {})[tostring(i)].snapshot_id, lookup(var.en_options, "snapshot_id", local.defaults.snapshot_id))
+      service_account = try(lookup(var.en_options, "options", {})[tostring(i)].service_account, lookup(var.en_options, "service_account", null))
     }
   ]
 }

--- a/terraform/gcp/modules/private-layer1/main.tf
+++ b/terraform/gcp/modules/private-layer1/main.tf
@@ -32,6 +32,8 @@ module "cn" {
   metadata = merge(var.metadata, {
     Name = format("%s-cn-%d", var.name, count.index + 1)
   })
+
+  service_account = local.get_cn_node_options[count.index].service_account
 }
 
 module "pn" {
@@ -68,6 +70,8 @@ module "pn" {
   metadata = merge(var.metadata, {
     Name = format("%s-pn-%d", var.name, count.index + 1)
   })
+
+  service_account = local.get_pn_node_options[count.index].service_account
 }
 
 module "en" {
@@ -104,6 +108,8 @@ module "en" {
   metadata = merge(var.metadata, {
     Name = format("%s-en-%d", var.name, count.index + 1)
   })
+
+  service_account = local.get_en_node_options[count.index].service_account
 }
 
 module "monitor" {
@@ -136,6 +142,8 @@ module "monitor" {
   metadata = merge(var.metadata, {
     Name = format("%s-monitor", var.name)
   })
+
+  service_account = null
 }
 
 # Provisioner for CN nodes with compute disk


### PR DESCRIPTION
# Description

https://github.com/kaiachain/kaiaspray/pull/66 PR creates a service_account variable, but it is not passed to "cn", "pn", "en" modules. So this PR passes it to them.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* Public Cloud:
* OS verson:
* Kaia version:
* Ansible version:
* Terraform version:

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
