### PR TITLE
aws: add custom vpc, subnet, security_group, and key_file

### DIFF
--- a/terraform/aws/modules/kaia-node/main.tf
+++ b/terraform/aws/modules/kaia-node/main.tf
@@ -1,7 +1,7 @@
 resource "aws_instance" "this" {
   ami                         = var.ami_id
   instance_type               = var.instance_type
-  vpc_security_group_ids      = var.security_group_ids
+  vpc_security_group_ids      = [var.security_group_id]
   associate_public_ip_address = true
   key_name                    = var.key_name
   subnet_id                   = var.subnet_id

--- a/terraform/aws/modules/kaia-node/variables.tf
+++ b/terraform/aws/modules/kaia-node/variables.tf
@@ -18,9 +18,9 @@ variable "key_name" {
   description = "A key pair is used to control login access to instance"
 }
 
-variable "security_group_ids" {
-  type        = list(string)
-  description = "Security group Ids to attach to instance"
+variable "security_group_id" {
+  type        = string
+  description = "Security group ID to attach to instance"
 }
 
 variable "subnet_id" {

--- a/terraform/aws/modules/keypair/locals.tf
+++ b/terraform/aws/modules/keypair/locals.tf
@@ -6,9 +6,8 @@ locals {
       ManagedBy = "terraform"
     }
   )
+  
+  # Extract key name from existing private key path
+  existing_key_name = var.create_aws_key_pair ? var.name : replace(basename(var.ssh_existing_private_key_path), ".pem", "")
 }
 
-data "aws_key_pair" "this" {
-  count    = var.create_aws_key_pair == false ? 1 : 0
-  key_name = var.name
-}

--- a/terraform/aws/modules/keypair/main.tf
+++ b/terraform/aws/modules/keypair/main.tf
@@ -21,3 +21,9 @@ resource "local_sensitive_file" "this" {
   filename        = var.ssh_private_key_path
   file_permission = "0400"
 }
+
+locals {
+  # Use the appropriate key and public key based on configuration
+  private_key_path = var.create_aws_key_pair ? basename(var.ssh_private_key_path) : var.ssh_existing_private_key_path
+  public_key = var.create_aws_key_pair ? tls_private_key.this[0].public_key_openssh : file(var.ssh_existing_public_key_path)
+}

--- a/terraform/aws/modules/keypair/outputs.tf
+++ b/terraform/aws/modules/keypair/outputs.tf
@@ -1,7 +1,19 @@
 output "key_name" {
-  value = try(aws_key_pair.this[0].key_name, data.aws_key_pair.this[0].key_name)
+  value = var.create_aws_key_pair ? aws_key_pair.this[0].key_name : local.existing_key_name
+}
+
+output "key_pair_name" {
+  value = var.name
+}
+
+output "ssh_public_key" {
+  value = local.public_key
 }
 
 output "ssh_private_key_path" {
-  value = try(local_sensitive_file.this[0].filename, null)
+  value = var.create_aws_key_pair ? local_sensitive_file.this[0].filename : var.ssh_existing_private_key_path
+}
+
+output "ssh_key_file_created" {
+  value = var.create_aws_key_pair ? local_sensitive_file.this[0].id : "existing_key"
 }

--- a/terraform/aws/modules/keypair/variables.tf
+++ b/terraform/aws/modules/keypair/variables.tf
@@ -19,3 +19,15 @@ variable "ssh_private_key_path" {
   type        = string
   description = "SSH private key path to save"
 }
+
+variable "ssh_existing_private_key_path" {
+  type        = string
+  description = "Path where the private key is saved. It is only used when create_gcp_key_pair is false"
+  default     = ""
+}
+
+variable "ssh_existing_public_key_path" {
+  type        = string
+  description = "Path where the public key is saved. It is only used when create_gcp_key_pair is false"
+  default     = ""
+}

--- a/terraform/aws/modules/private-layer1/main.tf
+++ b/terraform/aws/modules/private-layer1/main.tf
@@ -7,7 +7,7 @@ module "cn" {
   ami_id             = var.ami_id
   instance_type      = local.cn_options.instance_type
   key_name           = var.key_name
-  security_group_ids = [aws_security_group.layer1.id]
+  security_group_id = var.security_group_id != null && var.security_group_id != "" ? var.security_group_id : aws_security_group.layer1[0].id
   subnet_id          = var.subnet_ids[count.index % length(var.subnet_ids)]
 
   root_block_device = {
@@ -27,7 +27,7 @@ module "pn" {
   ami_id             = var.ami_id
   instance_type      = local.pn_options.instance_type
   key_name           = var.key_name
-  security_group_ids = [aws_security_group.layer1.id]
+  security_group_id = var.security_group_id != null && var.security_group_id != "" ? var.security_group_id : aws_security_group.layer1[0].id
   subnet_id          = var.subnet_ids[count.index % length(var.subnet_ids)]
 
   root_block_device = {
@@ -47,7 +47,7 @@ module "en" {
   ami_id             = var.ami_id
   instance_type      = local.en_options.instance_type
   key_name           = var.key_name
-  security_group_ids = [aws_security_group.layer1.id]
+  security_group_id = var.security_group_id != null && var.security_group_id != "" ? var.security_group_id : aws_security_group.layer1[0].id
   subnet_id          = var.subnet_ids[count.index % length(var.subnet_ids)]
 
   root_block_device = {
@@ -65,7 +65,7 @@ module "monitor" {
   ami_id             = var.ami_id
   instance_type      = local.monitor_options.instance_type
   key_name           = var.key_name
-  security_group_ids = [aws_security_group.monitor.id]
+  security_group_id = var.security_group_id != null && var.security_group_id != "" ? var.security_group_id : aws_security_group.layer1[0].id
   subnet_id          = var.subnet_ids[0]
 
   root_block_device = {

--- a/terraform/aws/modules/private-layer1/outputs.tf
+++ b/terraform/aws/modules/private-layer1/outputs.tf
@@ -15,9 +15,5 @@ output "monitor" {
 }
 
 output "layer1_sg_id" {
-  value = aws_security_group.layer1.id
-}
-
-output "monitor_sg_id" {
-  value = aws_security_group.monitor.id
+  value = var.security_group_id != null ? var.security_group_id : aws_security_group.layer1[0].id
 }

--- a/terraform/aws/modules/private-layer1/security_groups.tf
+++ b/terraform/aws/modules/private-layer1/security_groups.tf
@@ -1,4 +1,6 @@
 resource "aws_security_group" "layer1" {
+  count = var.security_group_id == null ? 1 : 0
+  
   name = format("%s-private-layer1-sg", var.name)
 
   vpc_id = var.vpc_id
@@ -10,7 +12,9 @@ resource "aws_security_group" "layer1" {
       { protocol = "tcp", from_port = 32323, to_port = 32324, cidr_blocks = ["0.0.0.0/0"] },
       { protocol = "udp", from_port = 32323, to_port = 32323, cidr_blocks = ["0.0.0.0/0"] },
       { protocol = "tcp", from_port = 50505, to_port = 50505, cidr_blocks = ["0.0.0.0/0"] },
-      { protocol = "tcp", from_port = 61001, to_port = 61001, security_groups = [aws_security_group.monitor.id] },
+      { protocol = "tcp", from_port = 61001, to_port = 61001, cidr_blocks = ["0.0.0.0/0"] },
+      { protocol = "tcp", from_port = 9090, to_port = 9090, cidr_blocks = ["0.0.0.0/0"] },
+      { protocol = "tcp", from_port = 3000, to_port = 3000, cidr_blocks = ["0.0.0.0/0"] },
     ]
 
     content {
@@ -33,33 +37,3 @@ resource "aws_security_group" "layer1" {
   tags = local.default_tags
 }
 
-resource "aws_security_group" "monitor" {
-  name = format("%s-monitor-sg", var.name)
-
-  vpc_id = var.vpc_id
-
-  dynamic "ingress" {
-    for_each = [
-      { protocol = "tcp", from_port = 22, to_port = 22, cidr_blocks = var.ssh_client_ips },
-      { protocol = "tcp", from_port = 9090, to_port = 9090, cidr_blocks = ["0.0.0.0/0"] },
-      { protocol = "tcp", from_port = 3000, to_port = 3000, cidr_blocks = ["0.0.0.0/0"] },
-    ]
-
-    content {
-      from_port   = ingress.value.from_port
-      to_port     = ingress.value.to_port
-      protocol    = ingress.value.protocol
-      cidr_blocks = try(ingress.value.cidr_blocks, null)
-      self        = try(ingress.value.self, null)
-    }
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags = local.default_tags
-}

--- a/terraform/aws/modules/private-layer1/variables.tf
+++ b/terraform/aws/modules/private-layer1/variables.tf
@@ -65,3 +65,9 @@ variable "monitor_options" {
   description = "The options to deploy monitor node"
   default     = {}
 }
+
+variable "security_group_id" {
+  type        = string
+  description = "Security group ID to use for the deployment"
+  default     = null
+}

--- a/terraform/aws/private-l1-scn/common.tf
+++ b/terraform/aws/private-l1-scn/common.tf
@@ -20,7 +20,7 @@ resource "aws_security_group" "layer2" {
       { protocol = "udp", from_port = 32323, to_port = 32323, cidr_blocks = ["0.0.0.0/0"] },
       { protocol = "tcp", from_port = 32323, to_port = 32324, self = true },
       { protocol = "udp", from_port = 32323, to_port = 32323, self = true },
-      { protocol = "tcp", from_port = 61001, to_port = 61001, security_groups = [module.layer1.monitor_sg_id] },
+      { protocol = "tcp", from_port = 61001, to_port = 61001, security_groups = [module.layer1.layer1_sg_id] },
     ]
 
     content {

--- a/terraform/aws/private-layer1/README.md
+++ b/terraform/aws/private-layer1/README.md
@@ -44,8 +44,7 @@ layer1 = {
     "private_ip" = "<private-ip>"
     "public_ip" = "<public-ip>"
   }
-  layer1_sg_id  = "<security-group-id>"
-  monitor_sg_id = "<security-group-id>"
+  layer1_sg_id = "<security-group-id>"
 }
 ```
 

--- a/terraform/aws/private-layer1/ansible-inventory.tf
+++ b/terraform/aws/private-layer1/ansible-inventory.tf
@@ -13,13 +13,24 @@ locals {
     "${path.module}/templates/groupvarsall.tftpl",
     {
       kaia_install_mode = var.deploy_options.kaia_install_mode
-      kaia_version      = var.deploy_options.kaia_version
+      kaia_version      = try(var.deploy_options.kaia_version, "")
       kaia_build_docker_base_image = var.deploy_options.kaia_build_docker_base_image
       kaia_num_cn       = var.cn_options.count
       kaia_num_pn       = var.pn_options.count
       kaia_num_en       = var.en_options.count
-      kaia_network_id   = var.deploy_options.kaia_network_id
-      kaia_chain_id     = var.deploy_options.kaia_chain_id
+      kaia_network      = try(var.deploy_options.kaia_network, "")
+      kaia_network_id   = try(var.deploy_options.kaia_network_id, "")
+      kaia_chain_id     = try(var.deploy_options.kaia_chain_id, "")
+      homi_extra_options_cn  = try(var.deploy_options.homi_extra_options.cn, "")
+      homi_extra_options_pn  = try(var.deploy_options.homi_extra_options.pn, "")
+      homi_extra_options_en  = try(var.deploy_options.homi_extra_options.en, "")
+      homi_extra_options_scn = try(var.deploy_options.homi_extra_options.scn, "")
+      homi_extra_options_spn = try(var.deploy_options.homi_extra_options.spn, "")
+      homi_extra_options_sen = try(var.deploy_options.homi_extra_options.sen, "")
+      cn_options        = jsonencode(var.cn_options)
+      pn_options        = jsonencode(var.pn_options)
+      en_options        = jsonencode(var.en_options)
+      deploy_options    = jsonencode(var.deploy_options)
     }
   )
 }

--- a/terraform/aws/private-layer1/ansible-inventory.tf
+++ b/terraform/aws/private-layer1/ansible-inventory.tf
@@ -2,7 +2,7 @@ locals {
   ansible_inventory = templatefile(
     "${path.module}/templates/inventory.tftpl",
     {
-      ansible_ssh_private_key_file = try(module.keypair.ssh_private_key_path, "<change-me>")
+      ansible_ssh_private_key_file = var.create_aws_key_pair ? basename(module.keypair.ssh_private_key_path) : module.keypair.ssh_private_key_path
       cn                           = try(module.layer1.cn, [])
       pn                           = try(module.layer1.pn, [])
       en                           = try(module.layer1.en, [])

--- a/terraform/aws/private-layer1/common.tf
+++ b/terraform/aws/private-layer1/common.tf
@@ -1,9 +1,11 @@
 module "keypair" {
   source = "../modules/keypair"
 
-  name                 = var.key_name == null ? local.name : var.key_name
-  create_aws_key_pair  = var.create_aws_key_pair
-  ssh_private_key_path = format("%s/../../../private-ssh-key.pem", path.module)
+  name                       = local.name
+  create_aws_key_pair        = var.create_aws_key_pair
+  ssh_private_key_path       = var.ssh_private_key_path
+  ssh_existing_private_key_path = var.ssh_existing_private_key_path
+  ssh_existing_public_key_path  = var.ssh_existing_public_key_path
 
   tags = var.tags
 }

--- a/terraform/aws/private-layer1/main.tf
+++ b/terraform/aws/private-layer1/main.tf
@@ -13,7 +13,7 @@ module "layer1" {
   ssh_client_ips = var.ssh_client_ips
 
   cn_options      = var.cn_options
-  pn_options      = var.cn_options
+  pn_options      = var.pn_options
   en_options      = var.en_options
   monitor_options = var.monitor_options
 

--- a/terraform/aws/private-layer1/main.tf
+++ b/terraform/aws/private-layer1/main.tf
@@ -4,8 +4,9 @@ module "layer1" {
   name = local.name
 
   aws_region = var.aws_region
-  vpc_id     = module.vpc.vpc_id
-  subnet_ids = module.vpc.public_subnets
+  vpc_id     = var.vpc_id != null ? var.vpc_id : module.vpc[0].vpc_id
+  subnet_ids = length(var.subnet_ids) > 0 ? var.subnet_ids : module.vpc[0].public_subnets
+  security_group_id = var.security_group_id
 
   ami_id         = data.aws_ami.this.id
   key_name       = local.key_name

--- a/terraform/aws/private-layer1/templates/groupvarsall.tftpl
+++ b/terraform/aws/private-layer1/templates/groupvarsall.tftpl
@@ -1,10 +1,13 @@
-# Installation mode: 'build' or 'package'
-# - build: Build from source code
+# Installation mode: 'build' or 'package' or 'build_remote'
+# - build: Build from source code locally
 # - package: Install from package repository
+# - build_remote: Build from source code on remote host
 # Kaia installation mode
 kaia_install_mode: "${kaia_install_mode}"
 
+%{ if kaia_version != "" ~}
 kaia_version: ${kaia_version}
+%{ endif ~}
 
 # Docker build settings
 kaia_build_docker_base_image: ${kaia_build_docker_base_image}
@@ -15,5 +18,20 @@ kaia_num_pn: ${kaia_num_pn}
 kaia_num_en: ${kaia_num_en}
 
 # Network configuration
+kaia_network: ${kaia_network}
 kaia_network_id: ${kaia_network_id}
 kaia_chain_id: ${kaia_chain_id}
+
+# Node-specific options
+cn_options: ${cn_options}
+pn_options: ${pn_options}
+en_options: ${en_options}
+deploy_options: ${deploy_options}
+
+# Homi extra options per node type
+homi_extra_options_cn: "${homi_extra_options_cn}"
+homi_extra_options_pn: "${homi_extra_options_pn}"
+homi_extra_options_en: "${homi_extra_options_en}"
+homi_extra_options_scn: "${homi_extra_options_scn}"
+homi_extra_options_spn: "${homi_extra_options_spn}"
+homi_extra_options_sen: "${homi_extra_options_sen}"

--- a/terraform/aws/private-layer1/templates/inventory.tftpl
+++ b/terraform/aws/private-layer1/templates/inventory.tftpl
@@ -1,20 +1,20 @@
 [cn]
 %{ for k, v in cn ~}
-cn${k+1} ansible_host=${v.public_ip} ansible_private_host=${v.private_ip} ansible_ssh_user=ec2-user ansible_ssh_private_key_file=${ basename(ansible_ssh_private_key_file) }
+cn${k+1} ansible_host=${v.public_ip} ansible_private_host=${v.private_ip} ansible_ssh_user=ec2-user ansible_ssh_private_key_file=${ansible_ssh_private_key_file}
 %{ endfor ~}
 
 [pn]
 %{ for k, v in pn ~}
-pn${k+1} ansible_host=${v.public_ip} ansible_private_host=${v.private_ip} ansible_ssh_user=ec2-user ansible_ssh_private_key_file=${ basename(ansible_ssh_private_key_file) }
+pn${k+1} ansible_host=${v.public_ip} ansible_private_host=${v.private_ip} ansible_ssh_user=ec2-user ansible_ssh_private_key_file=${ansible_ssh_private_key_file}
 %{ endfor ~}
 
 [en]
 %{ for k, v in en ~}
-en${k+1} ansible_host=${v.public_ip} ansible_private_host=${v.private_ip} ansible_ssh_user=ec2-user ansible_ssh_private_key_file=${ basename(ansible_ssh_private_key_file) }
+en${k+1} ansible_host=${v.public_ip} ansible_private_host=${v.private_ip} ansible_ssh_user=ec2-user ansible_ssh_private_key_file=${ansible_ssh_private_key_file}
 %{ endfor ~}
 
 [monitor]
-monitor ansible_host=${monitor.public_ip} ansible_ssh_user=ec2-user ansible_ssh_private_key_file=${ basename(ansible_ssh_private_key_file) }
+monitor ansible_host=${monitor.public_ip} ansible_ssh_user=ec2-user ansible_ssh_private_key_file=${ansible_ssh_private_key_file}
 
 [localhost]
 localhost ansible_host=127.0.0.1 ansible_connection=local

--- a/terraform/aws/private-layer1/variables.tf
+++ b/terraform/aws/private-layer1/variables.tf
@@ -68,3 +68,39 @@ variable "monitor_options" {
   description = "The options to deploy monitor node"
   default     = {}
 }
+
+variable "ssh_existing_private_key_path" {
+  type        = string
+  description = "Path where the private key is saved. It is only used when create_gcp_key_pair is false."
+  default     = ""
+}
+
+variable "ssh_existing_public_key_path" {
+  type        = string
+  description = "Path where the public key is saved. It is only used when create_gcp_key_pair is false."
+  default     = ""
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID to use for the deployment"
+  default     = null
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "List of subnet IDs to use for the deployment"
+  default     = []
+}
+
+variable "security_group_id" {
+  type        = string
+  description = "Security group ID to use for the deployment"
+  default     = null
+}
+
+variable "ssh_private_key_path" {
+  type        = string
+  description = "Path where the SSH private key will be saved"
+  default     = "../../../aws-private-ssh-key.pem"
+}

--- a/terraform/aws/private-layer1/vpc.tf
+++ b/terraform/aws/private-layer1/vpc.tf
@@ -1,4 +1,6 @@
 module "vpc" {
+  count = var.vpc_id == null ? 1 : 0
+  
   source = "terraform-aws-modules/vpc/aws"
 
   name               = local.name


### PR DESCRIPTION
# Description

This PR adds options for custom vpc, subnet, security_group, and key_file at aws.
If custom resources are provided, it will not create the resources. Instead, it will use already created custom resources.

```
# terraform.tfvars
vpc_id    = "vpc-07xxxxxxxxxxxx"
subnet_ids = ["subnet-0axxxxxxxxxxxx"]
security_group_id = "sg-0fxxxxxxxxxxxxx"

create_aws_key_pair = false
ssh_existing_private_key_path = "/root/.ssh/xxx.pem"
ssh_existing_public_key_path  = "/root/.ssh/xxx.pub"
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* Public Cloud:
* OS verson:
* Kaia version:
* Ansible version:
* Terraform version:

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
