### PR TITLE
gcp: resize the secondary disk

### DIFF
--- a/terraform/gcp/modules/private-layer1/mount_disk.sh
+++ b/terraform/gcp/modules/private-layer1/mount_disk.sh
@@ -28,6 +28,25 @@ if ! blkid "$DISK_PATH" &>/dev/null; then
   mkfs.$FILESYSTEM "$DISK_PATH"
 else
   echo "[INFO] Filesystem already exists on $DISK_PATH"
+  # Resize ext4 filesystem to use full disk capacity (for snapshot-based disks)
+  if command -v resize2fs >/dev/null 2>&1; then
+    echo "[INFO] Checking filesystem before resize..."
+    set +e  # Temporarily disable exit on error for e2fsck
+    e2fsck -f -y "$DISK_PATH"
+    e2fsck_exit_code=$?
+    set -e  # Re-enable exit on error
+    # e2fsck exit codes: 0=no errors, 1=errors fixed, 2=errors fixed (reboot needed)
+    if [ $e2fsck_exit_code -le 2 ]; then
+      echo "[INFO] Filesystem check completed successfully"
+      echo "[INFO] Resizing ext4 filesystem to use full disk capacity..."
+      resize2fs "$DISK_PATH"
+      echo "[INFO] Filesystem resized successfully"
+    else
+      echo "[WARNING] Filesystem check failed (exit code: $e2fsck_exit_code). Skipping resize."
+    fi
+  else
+    echo "[WARNING] resize2fs not found. You may need to manually resize the filesystem."
+  fi
 fi
 
 # Create and mount


### PR DESCRIPTION
# Description

This PR resizes the secondary disk such as snapshot disk.

When resize, mount_disk.sh works like below.
```
module.layer1.null_resource.en_disk_mount["0"] (remote-exec): [INFO] Mount point: /var/kend
module.layer1.null_resource.en_disk_mount["0"] (remote-exec): [INFO] Module name: kend
module.layer1.null_resource.en_disk_mount["0"] (remote-exec): [INFO] Filesystem already exists on /dev/disk/by-id/google-snapshot-resize-test-en-1-disk
module.layer1.null_resource.en_disk_mount["0"] (remote-exec): [INFO] Checking filesystem before resize...
module.layer1.null_resource.en_disk_mount["0"] (remote-exec): e2fsck 1.46.5 (30-Dec-2021)
module.layer1.null_resource.en_disk_mount["0"] (remote-exec): /dev/disk/by-id/google-snapshot-resize-test-en-1-disk: recovering journal
module.layer1.null_resource.en_disk_mount["0"] (remote-exec): Pass 1: Checking inodes, blocks, and sizes
module.layer1.null_resource.en_disk_mount["0"] (remote-exec): Pass 2: Checking directory structure
module.layer1.null_resource.en_disk_mount["0"] (remote-exec): Pass 3: Checking directory connectivity
module.layer1.null_resource.en_disk_mount["0"] (remote-exec): Pass 4: Checking reference counts
module.layer1.null_resource.en_disk_mount["0"] (remote-exec): Pass 5: Checking group summary information
module.layer1.null_resource.en_disk_mount["0"] (remote-exec): Free blocks count wrong (110928049, counted=110545414).
module.layer1.null_resource.en_disk_mount["0"] (remote-exec): Fix? yes

module.layer1.null_resource.en_disk_mount["0"] (remote-exec): Free inodes count wrong (65324927, counted=65324536).
module.layer1.null_resource.en_disk_mount["0"] (remote-exec): Fix? yes


module.layer1.null_resource.en_disk_mount["0"] (remote-exec): /dev/disk/by-id/google-snapshot-resize-test-en-1-disk: ***** FILE SYSTEM WAS MODIFIED *****
module.layer1.null_resource.en_disk_mount["0"] (remote-exec): /dev/disk/by-id/google-snapshot-resize-test-en-1-disk: 211464/65536000 files (63.7% non-contiguous), 151598586/262144000 blocks
module.layer1.null_resource.en_disk_mount["0"] (remote-exec): [INFO] Filesystem check completed successfully
module.layer1.null_resource.en_disk_mount["0"] (remote-exec): [INFO] Resizing ext4 filesystem to use full disk capacity...
module.layer1.null_resource.en_disk_mount["0"] (remote-exec): resize2fs 1.46.5 (30-Dec-2021)
module.layer1.null_resource.en_disk_mount["0"] (remote-exec): Resizing the filesystem on /dev/disk/by-id/google-snapshot-resize-test-en-1-disk to 524288000 (4k) blocks.
module.layer1.null_resource.en_disk_mount["0"]: Still creating... [30s elapsed]
module.layer1.null_resource.en_disk_mount["0"] (remote-exec): The filesystem on /dev/disk/by-id/google-snapshot-resize-test-en-1-disk is now 524288000 (4k) blocks long.

module.layer1.null_resource.en_disk_mount["0"] (remote-exec): [INFO] Filesystem resized successfully
module.layer1.null_resource.en_disk_mount["0"] (remote-exec): [INFO] Mounted /dev/disk/by-id/google-snapshot-resize-test-en-1-disk to /var/kend
module.layer1.null_resource.en_disk_mount["0"] (remote-exec): [INFO] fstab entry added
module.layer1.null_resource.en_disk_mount["0"]: Creation complete after 35s [id=2990745699113014623]

Apply complete! Resources: 10 added, 0 changed, 0 destroyed.
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* Public Cloud:
* OS verson:
* Kaia version:
* Ansible version:
* Terraform version:

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
