### PR TITLE
ansible: update roles to support ansible 2.19

### DIFF
--- a/roles/build/tasks/build_local.yml
+++ b/roles/build/tasks/build_local.yml
@@ -44,10 +44,10 @@
     # - force compile is true
     kaia_build_required: >-
       {{ (kaia_build_required | default([])) + [ (
-          kaia_build_check_file_stats.results[item].stat.exists == False
-          or kaia_build_skip_if_exists == False
+          not kaia_build_check_file_stats.results[item].stat.exists
+          or not kaia_build_skip_if_exists
           or git_info.results[item].before != git_info.results[item].after
-          or kaia_build_force_compile == True
+          or kaia_build_force_compile
       ) ] }}
   loop: "{{ range(0, total_builds | int) | list }}"
 
@@ -74,9 +74,7 @@
     src: "{{ kaia_build_dir }}-{{ build_identifiers[item[0]] }}/output/klaytn-docker-pkg/bin/{{ item[1] }}"
     mode: preserve
   when: kaia_build_required[item[0]]
-  with_nested:
-    - "{{ range(0, total_builds | int) | list }}"
-    - ['kbn', 'kcn', 'kpn', 'ken', 'kscn', 'kspn', 'ksen']
+  loop: "{{ range(0, total_builds | int) | list | product(['kbn', 'kcn', 'kpn', 'ken', 'kscn', 'kspn', 'ksen']) | list }}"
 
 # There may be multiple git dirs to build different versions of kaia binaries,
 # however we don't need to use different versions of homi to generate genesis and node keys.
@@ -94,6 +92,12 @@
     src: "{{ kaia_build_dir }}-{{ build_identifiers[0] }}/build/bin/homi"
     mode: preserve
 
+- name: Build - Remove existing bin directory if it exists
+  ansible.builtin.file:
+    path: "{{ bin_dir }}"
+    state: absent
+  when: total_builds | int > 0
+
 - name: Build - Create symbolic link to first bin directory
   ansible.builtin.file:
     src: "{{ bin_dir }}-{{ build_identifiers[0] }}"
@@ -107,9 +111,7 @@
     src: "{{ kaia_build_dir }}-{{ build_identifiers[item[0]] }}/build/rpm/etc/init.d/{{ item[1] }}"
     mode: preserve
   when: kaia_build_required[item[0]]
-  with_nested:
-    - "{{ range(0, total_builds | int) | list }}"
-    - ['kbnd', 'kcnd', 'kpnd', 'kend', 'kscnd', 'kspnd', 'ksend']
+  loop: "{{ range(0, total_builds | int) | list | product(['kbnd', 'kcnd', 'kpnd', 'kend', 'kscnd', 'kspnd', 'ksend']) | list }}"
 
 - name: Build - Creating an empty file for checking
   ansible.builtin.file:

--- a/roles/build/tasks/build_remote.yml
+++ b/roles/build/tasks/build_remote.yml
@@ -32,7 +32,7 @@
     kaia_build_required: True
   when:
     - kaia_build_check_file_stats.results | selectattr('stat.exists', 'equalto', false) | list | length > 0 or 
-      kaia_build_skip_if_exists == False
+      not kaia_build_skip_if_exists
 
 - name: Build Remote - Get first available host from inventory
   ansible.builtin.set_fact:
@@ -145,9 +145,7 @@
     src: "~/kaia_build-{{ build_identifiers[item[0]] }}/build/bin/{{ item[1] }}"
     dest: "{{ bin_dir }}-{{ build_identifiers[item[0]] }}/"
     flat: yes
-  with_nested:
-    - "{{ range(0, total_builds | int) | list }}"
-    - ['kbn', 'kcn', 'kpn', 'ken', 'kscn', 'kspn', 'ksen']
+  loop: "{{ range(0, total_builds | int) | list | product(['kbn', 'kcn', 'kpn', 'ken', 'kscn', 'kspn', 'ksen']) | list }}"
   delegate_to: "{{ remote_build_host }}"
   when:
     - kaia_build_required
@@ -158,9 +156,7 @@
     src: "~/kaia_build-{{ build_identifiers[item[0]] }}/build/rpm/etc/init.d/{{ item[1] }}"
     dest: "{{ bin_dir }}-{{ build_identifiers[item[0]] }}/"
     flat: yes
-  with_nested:
-    - "{{ range(0, total_builds | int) | list }}"
-    - ['kbnd', 'kcnd', 'kpnd', 'kend', 'kscnd', 'kspnd', 'ksend']
+  loop: "{{ range(0, total_builds | int) | list | product(['kbnd', 'kcnd', 'kpnd', 'kend', 'kscnd', 'kspnd', 'ksend']) | list }}"
   delegate_to: "{{ remote_build_host }}"
   when:
     - kaia_build_required
@@ -170,9 +166,7 @@
   ansible.builtin.file:
     path: "{{ bin_dir }}-{{ build_identifiers[item[0]] }}/{{ item[1] }}"
     mode: '0755'
-  with_nested:
-    - "{{ range(0, total_builds | int) | list }}"
-    - ['kbn', 'kcn', 'kpn', 'ken', 'kscn', 'kspn', 'ksen']
+  loop: "{{ range(0, total_builds | int) | list | product(['kbn', 'kcn', 'kpn', 'ken', 'kscn', 'kspn', 'ksen']) | list }}"
   when:
     - kaia_build_required
     - not kaia_build_check_file_stats.results[item[0]].stat.exists or not kaia_build_skip_if_exists
@@ -181,9 +175,7 @@
   ansible.builtin.file:
     path: "{{ bin_dir }}-{{ build_identifiers[item[0]] }}/{{ item[1] }}"
     mode: '0755'
-  with_nested:
-    - "{{ range(0, total_builds | int) | list }}"
-    - ['kbnd', 'kcnd', 'kpnd', 'kend', 'kscnd', 'kspnd', 'ksend']
+  loop: "{{ range(0, total_builds | int) | list | product(['kbnd', 'kcnd', 'kpnd', 'kend', 'kscnd', 'kspnd', 'ksend']) | list }}"
   when:
     - kaia_build_required
     - not kaia_build_check_file_stats.results[item[0]].stat.exists or not kaia_build_skip_if_exists
@@ -214,6 +206,14 @@
   when:
     - kaia_build_required
     - not kaia_build_check_file_stats.results[0].stat.exists or not kaia_build_skip_if_exists
+
+- name: Build Remote - Remove existing bin directory if it exists
+  ansible.builtin.file:
+    path: "{{ bin_dir }}"
+    state: absent
+  when: 
+    - total_builds | int > 0
+    - kaia_build_required
 
 - name: Build Remote - Create symbolic link to first bin directory
   ansible.builtin.file:

--- a/roles/en-scn-init/defaults/main.yml
+++ b/roles/en-scn-init/defaults/main.yml
@@ -42,7 +42,7 @@ kaia_conf_override:
 
 kaia_chaindata_timestamp: latest
 
-kaia_bridge_enabled: 1
+kaia_bridge_enabled: true
 kaia_bridge_node_type:
 kaia_bridge_node_num:
 

--- a/roles/en-scn-init/tasks/init_scn.yml
+++ b/roles/en-scn-init/tasks/init_scn.yml
@@ -53,7 +53,7 @@
     - name: Replace default IP with node IP
       become: yes
       command: "sed -i '0,/0.0.0.0/{s//{{ hostvars[item].ansible_host }}/}' {{ kaia_conf.DATA_DIR }}/static-nodes.json"
-      with_items: "{{ groups.scn }}"
+      loop: "{{ groups.scn }}"
       loop_control:
         index_var: index
   when: 
@@ -115,7 +115,7 @@
     public_ip: "{{ hostvars[item].ansible_host }}"
     private_ip: "{{ hostvars[item].ansible_private_host }}"
   register: validator_result
-  with_items: "{{ groups.scn }}"
+  loop: "{{ groups.scn }}"
   loop_control:
     index_var: index
   when: 
@@ -126,7 +126,7 @@
   copy:
     dest: "{{ kaia_conf.DATA_DIR }}/validator{{ index+1 }}"
     content: "{{ item.validator }}"
-  with_items: "{{ validator_result.results }}"
+  loop: "{{ validator_result.results }}"
   loop_control:
     index_var: index
   when: 
@@ -154,13 +154,13 @@
       ansible.builtin.slurp:
         src: "{{ '/'.join((homi_results_dir, 'keys', 'nodekey' + item)) }}"
       register: nodekey_slurpfile
-      with_sequence: start=1 end={{ groups.scn|length }}
+      loop: "{{ range(1, groups.scn|length + 1) | list }}"
 
     - name: Read validator file
       ansible.builtin.slurp:
         src: "{{ '/'.join((kaia_conf.DATA_DIR, 'validator' + item)) }}"
       register: validator_slurpfile
-      with_sequence: start=1 end={{ groups.scn|length }}
+      loop: "{{ range(1, groups.scn|length + 1) | list }}"
 
     - set_fact:
         genesis: "{{ genesis_slurpfile['content'] | b64decode }}"

--- a/roles/en-scn-init/tasks/install_package.yml
+++ b/roles/en-scn-init/tasks/install_package.yml
@@ -39,7 +39,7 @@
   file:
     state: directory
     path: "{{ item }}"
-  with_items:
+  loop:
   - "{{ kaia_conf.DATA_DIR }}"
   - "{{ kaia_conf.LOG_DIR }}"
 

--- a/roles/kaiaspray-defaults/defaults/main.yml
+++ b/roles/kaiaspray-defaults/defaults/main.yml
@@ -28,7 +28,7 @@ kaia_service_chain_id:
 
 kaia_custom_topology:
 
-kaia_bridge_enabled: 0
+kaia_bridge_enabled: false
 
 kaia_port: 32323
 kaia_main_bridge_port: 50505

--- a/roles/local-init/tasks/download_package_darwin.yml
+++ b/roles/local-init/tasks/download_package_darwin.yml
@@ -21,7 +21,7 @@
     keep_newer: yes
   register: extract_result
   when:
-  - check_package_file.stat.exists == False
+  - not check_package_file.stat.exists
 
 - name: "{{ package_name }}: Copy binary"
   copy:
@@ -29,7 +29,7 @@
     dest: "{{ bin_dir }}/{{ package_name }}"
     mode: '0755'
   when:
-  - check_package_file.stat.exists == False
+  - not check_package_file.stat.exists
 
 - name: "{{ package_name }}: Clean-up"
   file:
@@ -39,4 +39,4 @@
   - "{{ cache_dir }}/{{ extract_result.files[0] }}"
   - "{{ download_result.dest }}"
   when:
-  - check_package_file.stat.exists == False
+  - not check_package_file.stat.exists

--- a/roles/local-init/tasks/download_package_linux.yml
+++ b/roles/local-init/tasks/download_package_linux.yml
@@ -11,7 +11,7 @@
   register: download_result
   when:
   - ansible_system == "Linux"
-  - check_package_file.stat.exists == False
+  - not check_package_file.stat.exists
 
 - name: "{{ package_name }}: Unarchive Package"
   unarchive:
@@ -21,7 +21,7 @@
     keep_newer: yes
   register: extract_result
   when:
-  - check_package_file.stat.exists == False
+  - not check_package_file.stat.exists
 
 - name: "{{ package_name }}: Copy binary"
   copy:
@@ -29,7 +29,7 @@
     dest: "{{ bin_dir }}/{{ package_name }}"
     mode: '0755'
   when:
-  - check_package_file.stat.exists == False
+  - not check_package_file.stat.exists
 
 - name: "{{ package_name }}: Clean-up"
   file:
@@ -39,4 +39,4 @@
   - "{{ cache_dir }}/{{ extract_result.files[0] }}"
   - "{{ download_result.dest }}"
   when:
-  - check_package_file.stat.exists == False
+  - not check_package_file.stat.exists

--- a/roles/local-init/tasks/genesis.yml
+++ b/roles/local-init/tasks/genesis.yml
@@ -13,7 +13,7 @@
   - localhost
   when:
   - ctx.num > 0
-  - check_nodekey_file.stat.exists == False
+  - not check_nodekey_file.stat.exists
 
 - name: Convert and get validator data
   kaia_validator:

--- a/roles/local-init/tasks/main.yml
+++ b/roles/local-init/tasks/main.yml
@@ -1,4 +1,17 @@
 ---
+- name: Create required directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    mode: '0755'
+  loop:
+  - "{{ cache_dir }}"
+  - "{{ bin_dir }}"
+  - "{{ homi_output_dir }}"
+  - "{{ kaia_build_dir }}"
+  tags:
+  - localhost
+
 - name: Start to download dependencies
   include_tasks: download_dependency.yml
   tags:
@@ -41,7 +54,7 @@
 
 - name: Generate genesis.json & nodekey & validator
   include_tasks: genesis.yml
-  with_items:
+  loop:
   - { type: "cn", num: "{{ kaia_num_cn }}", network_id: "{{ kaia_network_id }}", chain_id: "{{ kaia_chain_id }}" }
   - { type: "pn", num: "{{ kaia_num_pn }}", network_id: "{{ kaia_network_id }}", chain_id: "{{ kaia_chain_id }}"  }
   - { type: "en", num: "{{ kaia_num_en }}", network_id: "{{ kaia_network_id }}", chain_id: "{{ kaia_chain_id }}"  }
@@ -57,7 +70,7 @@
 
 - name: Generate static-nodes.json
   include_tasks: static_nodes.yml
-  with_items:
+  loop:
   - { is_service_chain: False, num_cn: "{{ kaia_num_cn }}", num_pn: "{{ kaia_num_pn }}", num_en: "{{ kaia_num_en }}" }
   - { is_service_chain: True, num_cn: "{{ kaia_num_scn }}", num_pn: "{{ kaia_num_spn }}", num_en: "{{ kaia_num_sen }}" }
   loop_control:

--- a/roles/local-init/tasks/main_bridges.yml
+++ b/roles/local-init/tasks/main_bridges.yml
@@ -22,9 +22,9 @@
 
 - name: Bridge - Generate main-bridges.json
   copy:
-    content: "{{ item.value['knis'] }}"
+    content: "{{ item.value.knis | to_json }}"
     dest: "{{ homi_output_dir }}/bridge/main-bridges.json"
-  with_dict: "{{ main_bridges_result['nodes'] }}"
+  loop: "{{ main_bridges_result.nodes | dict2items }}"
   when:
   - kaia_bridge_enabled
   tags:

--- a/roles/local-init/tasks/static_nodes.yml
+++ b/roles/local-init/tasks/static_nodes.yml
@@ -21,8 +21,8 @@
 
 - name: Generate static-nodes.json
   copy:
-    content: "{{ item.value['knis'] }}"
-    dest: "{{ homi_output_dir }}/{{ item.value['node_type'] }}/scripts/static-nodes{{ item.value['node_num'] }}.json"
-  with_dict: "{{ static_nodes_result['static_nodes'] }}"
+    content: "{{ item.value.knis | to_json }}"
+    dest: "{{ homi_output_dir }}/{{ item.value.node_type }}/scripts/static-nodes{{ item.value.node_num }}.json"
+  loop: "{{ static_nodes_result.static_nodes | dict2items }}"
   when:
   - ctx.num_cn > 0 or ctx.num_pn > 0 or ctx.num_en > 0

--- a/roles/monitor-init/tasks/setup_prometheus.yml
+++ b/roles/monitor-init/tasks/setup_prometheus.yml
@@ -16,37 +16,42 @@
   tags:
   - prometheus
 
+- name: "Generate nodes list for Prometheus"
+  set_fact:
+    prometheus_nodes: >-
+      {%- set nodes_list = [] -%}
+      {%- for host in groups['nodes'] -%}
+        {%- set group_names = hostvars[host]['group_names'] -%}
+        {%- if 'cn' in group_names -%}
+          {%- set type = 'cn' -%}
+        {%- elif 'pn' in group_names -%}
+          {%- set type = 'pn' -%}
+        {%- elif 'en' in group_names -%}
+          {%- set type = 'en' -%}
+        {%- elif 'scn' in group_names -%}
+          {%- set type = 'scn' -%}
+        {%- elif 'spn' in group_names -%}
+          {%- set type = 'spn' -%}
+        {%- elif 'sen' in group_names -%}
+          {%- set type = 'sen' -%}
+        {%- endif -%}
+        {%- set node_dict = {
+          'name': host,
+          'private_ip': hostvars[host]['ansible_private_host'],
+          'type': type
+        } -%}
+        {%- set _ = nodes_list.append(node_dict) -%}
+      {%- endfor -%}
+      {{ nodes_list }}
+  tags:
+  - prometheus
+
 - name: "Template Prometheus file_sd configuration"
   become: yes
   template:
     src: "templates/prometheus/kaia-nodes.yml.j2"
     dest: "{{ prometheus_conf_dir }}/kaia-nodes.yml"
     force: yes
-  vars:
-    nodes: |-
-      [
-      {% for host in groups['nodes'] -%}
-        {% set group_names = hostvars[host]['group_names'] %}
-        {% if 'cn' in group_names %}
-          {% set type = 'cn' %}
-        {% elif 'pn' in group_names %}
-          {% set type = 'pn' %}
-        {% elif 'en' in group_names %}
-          {% set type = 'en' %}
-        {% elif 'scn' in group_names %}
-          {% set type = 'scn' %}
-        {% elif 'spn' in group_names %}
-          {% set type = 'spn' %}
-        {% elif 'sen' in group_names %}
-          {% set type = 'sen' %}
-        {% endif %}
-        {
-          "name": "{{ host }}",
-          "private_ip": "{{ hostvars[host]['ansible_private_host'] }}" ,
-          "type": "{{ type }}"
-        },
-      {% endfor %}
-      ]
   tags:
   - prometheus
 

--- a/roles/monitor-init/templates/prometheus/kaia-nodes.yml.j2
+++ b/roles/monitor-init/templates/prometheus/kaia-nodes.yml.j2
@@ -1,4 +1,4 @@
-{% for node in nodes %}
+{% for node in prometheus_nodes %}
 - targets:
   - "{{ node['private_ip'] }}:{{ kaia_exporter_port }}"
   labels:

--- a/roles/node-init/defaults/main.yml
+++ b/roles/node-init/defaults/main.yml
@@ -40,6 +40,6 @@ kaia_conf_default:
   SC_SUB_BRIDGE_PORT: "{{ kaia_sub_bridge_port }}"
 kaia_conf_override:
 
-kaia_bridge_enabled: 0
+kaia_bridge_enabled: false
 kaia_bridge_node_type:
 kaia_bridge_node_num:

--- a/roles/node-init/tasks/copy_files.yml
+++ b/roles/node-init/tasks/copy_files.yml
@@ -59,8 +59,8 @@
     src: "{{ homi_output_dir }}/cn/scripts/genesis.json"
     dest: "/etc/{{ kaia_daemon_name }}/genesis.json"
   when:
-  - check_kaia_data_dir.stat.exists == False
-  - is_service_chain == False
+  - not check_kaia_data_dir.stat.exists
+  - not is_service_chain
   - kaia_network is none
 
 - name: "Initialization - Copy Genesis File"
@@ -69,7 +69,7 @@
     src: "{{ homi_output_dir }}/scn/scripts/genesis.json"
     dest: "/etc/{{ kaia_daemon_name }}/genesis.json"
   when:
-  - check_kaia_data_dir.stat.exists == False
+  - not check_kaia_data_dir.stat.exists
   - is_service_chain
   - kaia_network is none
 
@@ -79,5 +79,5 @@
     cmd: "k{{ kaia_node_type }} init --datadir {{ kaia_conf.DATA_DIR }} /etc/{{ kaia_daemon_name }}/genesis.json"
   when:
   - kaia_network is none
-  - check_kaia_data_dir.stat.exists == False
+  - not check_kaia_data_dir.stat.exists
 

--- a/roles/node-init/tasks/install_build.yml
+++ b/roles/node-init/tasks/install_build.yml
@@ -61,7 +61,7 @@
   file:
     state: directory
     path: "{{ item }}"
-  with_items:
+  loop:
   - "{{ kaia_conf.DATA_DIR }}"
   - "{{ kaia_conf.LOG_DIR }}"
 

--- a/roles/node-init/tasks/install_package.yml
+++ b/roles/node-init/tasks/install_package.yml
@@ -33,7 +33,7 @@
   file:
     state: directory
     path: "{{ item }}"
-  with_items:
+  loop:
   - "{{ kaia_conf.DATA_DIR }}"
   - "{{ kaia_conf.LOG_DIR }}"
 


### PR DESCRIPTION
# Description
- This PR updates ansible files in `roles` directory to support ansible 2.19 ([reference](https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_core_2.19.html?utm_source=chatgpt.com))
- change1. replace all `with_*` with `loop` or `loop+project`
- change2. integers (e.g., 1 or 0) are no longer implicitly treated as boolean true or false.
- change3. preserve native type of template

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* Public Cloud: gcp
* OS verson: macos
* Kaia version: v2.0.3
* Ansible version: 2.19
* Terraform version:

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
