### PR TITLE
terraform/gcp: support per-node region overrides, spot VMs, and static-nodes IP flag

### DIFF
--- a/library/kaia_static_nodes.py
+++ b/library/kaia_static_nodes.py
@@ -38,6 +38,7 @@ class ModuleRunner(object):
         self.homi_output_dir = module.params['homi_output_dir']
         self.is_service_chain = module.params['is_service_chain']
         self.topology = module.params['topology']
+        self.use_public_ip = module.params['use_public_ip']
 
         self.validate_params()
 
@@ -83,7 +84,8 @@ class ModuleRunner(object):
             for v2 in v1:
                 node_type2, node_num2 = split_node_name(v2)
                 validator = self.read_validator(node_type2, node_num2)
-                result['static_nodes'][k1]['knis'].append(validator['NodeInfo'])
+                kni_key = 'NodeInfo' if self.use_public_ip else 'PrivateNodeInfo'
+                result['static_nodes'][k1]['knis'].append(validator[kni_key])
 
         return result
 
@@ -94,6 +96,7 @@ def main():
             homi_output_dir=dict(type='str', required=True),
             is_service_chain=dict(type='bool', default=False),
             topology=dict(type='dict', required=True),
+            use_public_ip=dict(type='bool', default=True),
         ),
         supports_check_mode=False
     )
@@ -106,4 +109,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/roles/local-init/defaults/main.yml
+++ b/roles/local-init/defaults/main.yml
@@ -9,3 +9,4 @@ homi_extra_options_sen: ""
 homi_test_account_num: 16
 
 force_create_genesis: False
+static_nodes_use_public_ip: False

--- a/roles/local-init/tasks/genesis.yml
+++ b/roles/local-init/tasks/genesis.yml
@@ -8,7 +8,7 @@
 
 - name: "Generate {{ ctx.type }} data & genesis.json by Homi"
   shell: |
-    {{ homi_bin }} setup {{ homi_default_options }} {{ vars['homi_extra_options_' + ctx.type] | default('') }} --test-num {{ homi_test_account_num }} --cn-num {{ ctx.num }} --chainID {{ kaia_network_id }} --network-id {{ kaia_network_id }} -o {{ homi_output_dir }}/{{ ctx.type }} local
+    {{ homi_bin }} setup {{ homi_default_options }} {{ vars['homi_extra_options_' + ctx.type] | default('') }} --test-num {{ homi_test_account_num }} --cn-num {{ ctx.num }} --chainID {{ ctx.chain_id }} --network-id {{ ctx.network_id }} -o {{ homi_output_dir }}/{{ ctx.type }} local
   tags:
   - localhost
   when:

--- a/roles/local-init/tasks/static_nodes.yml
+++ b/roles/local-init/tasks/static_nodes.yml
@@ -15,6 +15,7 @@
     homi_output_dir: "{{ homi_output_dir }}"
     topology: "{{ topology_result.topology }}"
     is_service_chain: "{{ ctx.is_service_chain }}"
+    use_public_ip: "{{ static_nodes_use_public_ip }}"
   register: static_nodes_result
   when:
   - ctx.num_cn > 0 or ctx.num_pn > 0 or ctx.num_en > 0

--- a/terraform/gcp/modules/kaia-node/main.tf
+++ b/terraform/gcp/modules/kaia-node/main.tf
@@ -48,6 +48,18 @@ resource "google_compute_instance" "this" {
   metadata = merge(
     var.metadata,
   )
+
+  dynamic "scheduling" {
+    for_each = var.spot ? [1] : []
+
+    content {
+      automatic_restart           = false
+      instance_termination_action = var.spot_instance_termination_action
+      on_host_maintenance         = "TERMINATE"
+      preemptible                 = true
+      provisioning_model          = "SPOT"
+    }
+  }
 }
 
 resource "google_compute_disk" "this" {

--- a/terraform/gcp/modules/kaia-node/main.tf
+++ b/terraform/gcp/modules/kaia-node/main.tf
@@ -31,7 +31,8 @@ resource "google_compute_instance" "this" {
   }
 
   network_interface {
-    subnetwork = var.subnetwork
+    network    = var.network != "" ? var.network : null
+    subnetwork = var.subnetwork != "" ? var.subnetwork : null
 
     dynamic "access_config" {
       for_each = var.use_public_ip == true ? [1] : []

--- a/terraform/gcp/modules/kaia-node/variables.tf
+++ b/terraform/gcp/modules/kaia-node/variables.tf
@@ -78,3 +78,15 @@ variable "service_account" {
   description = "Service account to attach to the instance"
   default     = null
 }
+
+variable "spot" {
+  type        = bool
+  description = "Create this instance as a Spot VM"
+  default     = false
+}
+
+variable "spot_instance_termination_action" {
+  type        = string
+  description = "Termination action for Spot VM preemption"
+  default     = "STOP"
+}

--- a/terraform/gcp/modules/private-layer1/locals.tf
+++ b/terraform/gcp/modules/private-layer1/locals.tf
@@ -9,6 +9,8 @@ locals {
     zone = null
     network = var.network
     subnetwork = var.subnetwork
+    spot = false
+    spot_instance_termination_action = "STOP"
   }
 
   zone_suffixes = ["a", "b", "c"]
@@ -24,6 +26,8 @@ locals {
     zone = lookup(var.monitor_options, "zone", local.default_zone)
     network = lookup(var.monitor_options, "network", local.defaults.network)
     subnetwork = lookup(var.monitor_options, "subnetwork", local.defaults.subnetwork)
+    spot = try(var.monitor_options.spot, try(var.monitor_options.spot_vm, try(var.monitor_options.preemptible, false)))
+    spot_instance_termination_action = lookup(var.monitor_options, "spot_instance_termination_action", local.defaults.spot_instance_termination_action)
   }
 
   # Generate node options lists - can be used like get_cn_node_options[0]
@@ -38,6 +42,8 @@ locals {
       zone = try(lookup(var.cn_options, "options", {})[tostring(i)].zone, lookup(var.cn_options, "zone", null))
       network = try(lookup(var.cn_options, "options", {})[tostring(i)].network, lookup(var.cn_options, "network", local.defaults.network))
       subnetwork = try(lookup(var.cn_options, "options", {})[tostring(i)].subnetwork, lookup(var.cn_options, "subnetwork", local.defaults.subnetwork))
+      spot = try(lookup(var.cn_options, "options", {})[tostring(i)].spot, try(lookup(var.cn_options, "options", {})[tostring(i)].spot_vm, try(lookup(var.cn_options, "options", {})[tostring(i)].preemptible, try(var.cn_options.spot, try(var.cn_options.spot_vm, try(var.cn_options.preemptible, false))))))
+      spot_instance_termination_action = try(lookup(var.cn_options, "options", {})[tostring(i)].spot_instance_termination_action, lookup(var.cn_options, "spot_instance_termination_action", local.defaults.spot_instance_termination_action))
     }
   ]
 
@@ -52,6 +58,8 @@ locals {
       zone = try(lookup(var.pn_options, "options", {})[tostring(i)].zone, lookup(var.pn_options, "zone", null))
       network = try(lookup(var.pn_options, "options", {})[tostring(i)].network, lookup(var.pn_options, "network", local.defaults.network))
       subnetwork = try(lookup(var.pn_options, "options", {})[tostring(i)].subnetwork, lookup(var.pn_options, "subnetwork", local.defaults.subnetwork))
+      spot = try(lookup(var.pn_options, "options", {})[tostring(i)].spot, try(lookup(var.pn_options, "options", {})[tostring(i)].spot_vm, try(lookup(var.pn_options, "options", {})[tostring(i)].preemptible, try(var.pn_options.spot, try(var.pn_options.spot_vm, try(var.pn_options.preemptible, false))))))
+      spot_instance_termination_action = try(lookup(var.pn_options, "options", {})[tostring(i)].spot_instance_termination_action, lookup(var.pn_options, "spot_instance_termination_action", local.defaults.spot_instance_termination_action))
     }
   ]
 
@@ -66,6 +74,8 @@ locals {
       zone = try(lookup(var.en_options, "options", {})[tostring(i)].zone, lookup(var.en_options, "zone", null))
       network = try(lookup(var.en_options, "options", {})[tostring(i)].network, lookup(var.en_options, "network", local.defaults.network))
       subnetwork = try(lookup(var.en_options, "options", {})[tostring(i)].subnetwork, lookup(var.en_options, "subnetwork", local.defaults.subnetwork))
+      spot = try(lookup(var.en_options, "options", {})[tostring(i)].spot, try(lookup(var.en_options, "options", {})[tostring(i)].spot_vm, try(lookup(var.en_options, "options", {})[tostring(i)].preemptible, try(var.en_options.spot, try(var.en_options.spot_vm, try(var.en_options.preemptible, false))))))
+      spot_instance_termination_action = try(lookup(var.en_options, "options", {})[tostring(i)].spot_instance_termination_action, lookup(var.en_options, "spot_instance_termination_action", local.defaults.spot_instance_termination_action))
     }
   ]
 

--- a/terraform/gcp/modules/private-layer1/locals.tf
+++ b/terraform/gcp/modules/private-layer1/locals.tf
@@ -5,13 +5,25 @@ locals {
     boot_disk_size = 100
     compute_disk_size = null
     snapshot_id = null
+    region = var.gcp_region
+    zone = null
+    network = var.network
+    subnetwork = var.subnetwork
   }
+
+  zone_suffixes = ["a", "b", "c"]
+
+  default_zone = length(var.zone_list) > 0 ? var.zone_list[0] : format("%s-a", var.gcp_region)
 
   monitor_options = {
     machine_type   = lookup(var.monitor_options, "machine_type", local.defaults.machine_type)
     boot_disk_size = lookup(var.monitor_options, "boot_disk_size", local.defaults.boot_disk_size)
     compute_disk_size = lookup(var.monitor_options, "compute_disk_size", local.defaults.compute_disk_size)
     snapshot_id = lookup(var.monitor_options, "snapshot_id", local.defaults.snapshot_id)
+    region = lookup(var.monitor_options, "region", var.gcp_region)
+    zone = lookup(var.monitor_options, "zone", local.default_zone)
+    network = lookup(var.monitor_options, "network", local.defaults.network)
+    subnetwork = lookup(var.monitor_options, "subnetwork", local.defaults.subnetwork)
   }
 
   # Generate node options lists - can be used like get_cn_node_options[0]
@@ -22,6 +34,10 @@ locals {
       compute_disk_size = try(lookup(var.cn_options, "options", {})[tostring(i)].compute_disk_size, lookup(var.cn_options, "compute_disk_size", local.defaults.compute_disk_size))
       snapshot_id = try(lookup(var.cn_options, "options", {})[tostring(i)].snapshot_id, lookup(var.cn_options, "snapshot_id", local.defaults.snapshot_id))
       service_account = try(lookup(var.cn_options, "options", {})[tostring(i)].service_account, lookup(var.cn_options, "service_account", null))
+      region = try(lookup(var.cn_options, "options", {})[tostring(i)].region, lookup(var.cn_options, "region", var.gcp_region))
+      zone = try(lookup(var.cn_options, "options", {})[tostring(i)].zone, lookup(var.cn_options, "zone", null))
+      network = try(lookup(var.cn_options, "options", {})[tostring(i)].network, lookup(var.cn_options, "network", local.defaults.network))
+      subnetwork = try(lookup(var.cn_options, "options", {})[tostring(i)].subnetwork, lookup(var.cn_options, "subnetwork", local.defaults.subnetwork))
     }
   ]
 
@@ -32,6 +48,10 @@ locals {
       compute_disk_size = try(lookup(var.pn_options, "options", {})[tostring(i)].compute_disk_size, lookup(var.pn_options, "compute_disk_size", local.defaults.compute_disk_size))
       snapshot_id = try(lookup(var.pn_options, "options", {})[tostring(i)].snapshot_id, lookup(var.pn_options, "snapshot_id", local.defaults.snapshot_id))
       service_account = try(lookup(var.pn_options, "options", {})[tostring(i)].service_account, lookup(var.pn_options, "service_account", null))
+      region = try(lookup(var.pn_options, "options", {})[tostring(i)].region, lookup(var.pn_options, "region", var.gcp_region))
+      zone = try(lookup(var.pn_options, "options", {})[tostring(i)].zone, lookup(var.pn_options, "zone", null))
+      network = try(lookup(var.pn_options, "options", {})[tostring(i)].network, lookup(var.pn_options, "network", local.defaults.network))
+      subnetwork = try(lookup(var.pn_options, "options", {})[tostring(i)].subnetwork, lookup(var.pn_options, "subnetwork", local.defaults.subnetwork))
     }
   ]
 
@@ -42,6 +62,83 @@ locals {
       compute_disk_size = try(lookup(var.en_options, "options", {})[tostring(i)].compute_disk_size, lookup(var.en_options, "compute_disk_size", local.defaults.compute_disk_size))
       snapshot_id = try(lookup(var.en_options, "options", {})[tostring(i)].snapshot_id, lookup(var.en_options, "snapshot_id", local.defaults.snapshot_id))
       service_account = try(lookup(var.en_options, "options", {})[tostring(i)].service_account, lookup(var.en_options, "service_account", null))
+      region = try(lookup(var.en_options, "options", {})[tostring(i)].region, lookup(var.en_options, "region", var.gcp_region))
+      zone = try(lookup(var.en_options, "options", {})[tostring(i)].zone, lookup(var.en_options, "zone", null))
+      network = try(lookup(var.en_options, "options", {})[tostring(i)].network, lookup(var.en_options, "network", local.defaults.network))
+      subnetwork = try(lookup(var.en_options, "options", {})[tostring(i)].subnetwork, lookup(var.en_options, "subnetwork", local.defaults.subnetwork))
     }
   ]
+
+  cn_node_settings = [
+    for i, options in local.get_cn_node_options : merge(options, {
+      zone = options.zone != null ? options.zone : (
+        options.region == var.gcp_region && length(var.zone_list) > 0
+        ? var.zone_list[i % length(var.zone_list)]
+        : format("%s-%s", options.region, local.zone_suffixes[i % length(local.zone_suffixes)])
+      )
+      network = options.network == "" ? "" : (
+        startswith(options.network, "https://") || startswith(options.network, "projects/")
+        ? options.network
+        : format("projects/%s/global/networks/%s", var.project_id, options.network)
+      )
+      subnetwork = options.subnetwork == "" ? "" : (
+        startswith(options.subnetwork, "https://") || startswith(options.subnetwork, "projects/")
+        ? options.subnetwork
+        : format("projects/%s/regions/%s/subnetworks/%s", var.project_id, options.region, options.subnetwork)
+      )
+    })
+  ]
+
+  pn_node_settings = [
+    for i, options in local.get_pn_node_options : merge(options, {
+      zone = options.zone != null ? options.zone : (
+        options.region == var.gcp_region && length(var.zone_list) > 0
+        ? var.zone_list[i % length(var.zone_list)]
+        : format("%s-%s", options.region, local.zone_suffixes[i % length(local.zone_suffixes)])
+      )
+      network = options.network == "" ? "" : (
+        startswith(options.network, "https://") || startswith(options.network, "projects/")
+        ? options.network
+        : format("projects/%s/global/networks/%s", var.project_id, options.network)
+      )
+      subnetwork = options.subnetwork == "" ? "" : (
+        startswith(options.subnetwork, "https://") || startswith(options.subnetwork, "projects/")
+        ? options.subnetwork
+        : format("projects/%s/regions/%s/subnetworks/%s", var.project_id, options.region, options.subnetwork)
+      )
+    })
+  ]
+
+  en_node_settings = [
+    for i, options in local.get_en_node_options : merge(options, {
+      zone = options.zone != null ? options.zone : (
+        options.region == var.gcp_region && length(var.zone_list) > 0
+        ? var.zone_list[i % length(var.zone_list)]
+        : format("%s-%s", options.region, local.zone_suffixes[i % length(local.zone_suffixes)])
+      )
+      network = options.network == "" ? "" : (
+        startswith(options.network, "https://") || startswith(options.network, "projects/")
+        ? options.network
+        : format("projects/%s/global/networks/%s", var.project_id, options.network)
+      )
+      subnetwork = options.subnetwork == "" ? "" : (
+        startswith(options.subnetwork, "https://") || startswith(options.subnetwork, "projects/")
+        ? options.subnetwork
+        : format("projects/%s/regions/%s/subnetworks/%s", var.project_id, options.region, options.subnetwork)
+      )
+    })
+  ]
+
+  monitor_settings = merge(local.monitor_options, {
+    network = local.monitor_options.network == "" ? "" : (
+      startswith(local.monitor_options.network, "https://") || startswith(local.monitor_options.network, "projects/")
+      ? local.monitor_options.network
+      : format("projects/%s/global/networks/%s", var.project_id, local.monitor_options.network)
+    )
+    subnetwork = local.monitor_options.subnetwork == "" ? "" : (
+      startswith(local.monitor_options.subnetwork, "https://") || startswith(local.monitor_options.subnetwork, "projects/")
+      ? local.monitor_options.subnetwork
+      : format("projects/%s/regions/%s/subnetworks/%s", var.project_id, local.monitor_options.region, local.monitor_options.subnetwork)
+    )
+  })
 }

--- a/terraform/gcp/modules/private-layer1/main.tf
+++ b/terraform/gcp/modules/private-layer1/main.tf
@@ -14,6 +14,8 @@ module "cn" {
   use_public_ip = true
   region        = local.cn_node_settings[count.index].region
   network_tier  = var.network_tier
+  spot          = local.cn_node_settings[count.index].spot
+  spot_instance_termination_action = local.cn_node_settings[count.index].spot_instance_termination_action
 
   boot_disk = {
     image_id       = var.boot_image_id
@@ -53,6 +55,8 @@ module "pn" {
   use_public_ip = true
   region        = local.pn_node_settings[count.index].region
   network_tier  = var.network_tier
+  spot          = local.pn_node_settings[count.index].spot
+  spot_instance_termination_action = local.pn_node_settings[count.index].spot_instance_termination_action
 
   boot_disk = {
     image_id       = var.boot_image_id
@@ -92,6 +96,8 @@ module "en" {
   use_public_ip = true
   region        = local.en_node_settings[count.index].region
   network_tier  = var.network_tier
+  spot          = local.en_node_settings[count.index].spot
+  spot_instance_termination_action = local.en_node_settings[count.index].spot_instance_termination_action
 
   boot_disk = {
     image_id       = var.boot_image_id
@@ -127,6 +133,8 @@ module "monitor" {
   use_public_ip = true
   region        = local.monitor_settings.region
   network_tier  = var.network_tier
+  spot          = local.monitor_settings.spot
+  spot_instance_termination_action = local.monitor_settings.spot_instance_termination_action
 
   boot_disk = {
     image_id       = var.boot_image_id

--- a/terraform/gcp/modules/private-layer1/main.tf
+++ b/terraform/gcp/modules/private-layer1/main.tf
@@ -1,30 +1,31 @@
 module "cn" {
-  count = length(local.get_cn_node_options)
+  count = length(local.cn_node_settings)
 
   source = "../kaia-node"
 
   name         = format("%s-cn-%d", var.name, count.index + 1)
   
   # Get node settings with index-based overrides
-  machine_type = local.get_cn_node_options[count.index].machine_type
+  machine_type = local.cn_node_settings[count.index].machine_type
 
-  subnetwork    = var.subnetwork
-  zone          = var.zone_list[count.index % length(var.zone_list)]
+  network       = local.cn_node_settings[count.index].network
+  subnetwork    = local.cn_node_settings[count.index].subnetwork
+  zone          = local.cn_node_settings[count.index].zone
   use_public_ip = true
-  region        = var.gcp_region
+  region        = local.cn_node_settings[count.index].region
   network_tier  = var.network_tier
 
   boot_disk = {
     image_id       = var.boot_image_id
-    boot_disk_size = local.get_cn_node_options[count.index].boot_disk_size
+    boot_disk_size = local.cn_node_settings[count.index].boot_disk_size
   }
 
-  compute_disk = local.get_cn_node_options[count.index].compute_disk_size != null ? {
+  compute_disk = local.cn_node_settings[count.index].compute_disk_size != null ? {
     name        = format("%s-cn-%d-disk", var.name, count.index + 1)
     type        = "pd-ssd"
-    zone        = var.zone_list[count.index % length(var.zone_list)]
-    size        = local.get_cn_node_options[count.index].compute_disk_size
-    snapshot    = local.get_cn_node_options[count.index].snapshot_id
+    zone        = local.cn_node_settings[count.index].zone
+    size        = local.cn_node_settings[count.index].compute_disk_size
+    snapshot    = local.cn_node_settings[count.index].snapshot_id
   } : null
 
   tags = length(var.network_tags) > 0 ? concat(var.network_tags) : ["kaiaspray", "cn"]
@@ -33,36 +34,37 @@ module "cn" {
     Name = format("%s-cn-%d", var.name, count.index + 1)
   })
 
-  service_account = local.get_cn_node_options[count.index].service_account
+  service_account = local.cn_node_settings[count.index].service_account
 }
 
 module "pn" {
-  count = length(local.get_pn_node_options)
+  count = length(local.pn_node_settings)
 
   source = "../kaia-node"
 
   name         = format("%s-pn-%d", var.name, count.index + 1)
   
   # Get node settings with index-based overrides
-  machine_type = local.get_pn_node_options[count.index].machine_type
+  machine_type = local.pn_node_settings[count.index].machine_type
 
-  subnetwork    = var.subnetwork
-  zone          = var.zone_list[count.index % length(var.zone_list)]
+  network       = local.pn_node_settings[count.index].network
+  subnetwork    = local.pn_node_settings[count.index].subnetwork
+  zone          = local.pn_node_settings[count.index].zone
   use_public_ip = true
-  region        = var.gcp_region
+  region        = local.pn_node_settings[count.index].region
   network_tier  = var.network_tier
 
   boot_disk = {
     image_id       = var.boot_image_id
-    boot_disk_size = local.get_pn_node_options[count.index].boot_disk_size
+    boot_disk_size = local.pn_node_settings[count.index].boot_disk_size
   }
 
-  compute_disk = local.get_pn_node_options[count.index].compute_disk_size != null ? {
+  compute_disk = local.pn_node_settings[count.index].compute_disk_size != null ? {
     name = format("%s-pn-%d-disk", var.name, count.index + 1)
     type = "pd-ssd"
-    zone = var.zone_list[count.index % length(var.zone_list)]
-    size = local.get_pn_node_options[count.index].compute_disk_size
-    snapshot = local.get_pn_node_options[count.index].snapshot_id
+    zone = local.pn_node_settings[count.index].zone
+    size = local.pn_node_settings[count.index].compute_disk_size
+    snapshot = local.pn_node_settings[count.index].snapshot_id
   } : null
 
   tags = length(var.network_tags) > 0 ? concat(var.network_tags) : ["kaiaspray", "pn"]
@@ -71,36 +73,37 @@ module "pn" {
     Name = format("%s-pn-%d", var.name, count.index + 1)
   })
 
-  service_account = local.get_pn_node_options[count.index].service_account
+  service_account = local.pn_node_settings[count.index].service_account
 }
 
 module "en" {
-  count = length(local.get_en_node_options)
+  count = length(local.en_node_settings)
 
   source = "../kaia-node"
 
   name         = format("%s-en-%d", var.name, count.index + 1)
   
   # Get node settings with index-based overrides
-  machine_type = local.get_en_node_options[count.index].machine_type
+  machine_type = local.en_node_settings[count.index].machine_type
 
-  subnetwork    = var.subnetwork
-  zone          = var.zone_list[count.index % length(var.zone_list)]
+  network       = local.en_node_settings[count.index].network
+  subnetwork    = local.en_node_settings[count.index].subnetwork
+  zone          = local.en_node_settings[count.index].zone
   use_public_ip = true
-  region        = var.gcp_region
+  region        = local.en_node_settings[count.index].region
   network_tier  = var.network_tier
 
   boot_disk = {
     image_id       = var.boot_image_id
-    boot_disk_size = local.get_en_node_options[count.index].boot_disk_size
+    boot_disk_size = local.en_node_settings[count.index].boot_disk_size
   }
 
-  compute_disk = local.get_en_node_options[count.index].compute_disk_size != null ? {
+  compute_disk = local.en_node_settings[count.index].compute_disk_size != null ? {
     name = format("%s-en-%d-disk", var.name, count.index + 1)
     type = "pd-ssd"
-    zone = var.zone_list[count.index % length(var.zone_list)]
-    size = local.get_en_node_options[count.index].compute_disk_size
-    snapshot = local.get_en_node_options[count.index].snapshot_id
+    zone = local.en_node_settings[count.index].zone
+    size = local.en_node_settings[count.index].compute_disk_size
+    snapshot = local.en_node_settings[count.index].snapshot_id
   } : null
 
   tags = length(var.network_tags) > 0 ? concat(var.network_tags) : ["kaiaspray", "en"]
@@ -109,32 +112,33 @@ module "en" {
     Name = format("%s-en-%d", var.name, count.index + 1)
   })
 
-  service_account = local.get_en_node_options[count.index].service_account
+  service_account = local.en_node_settings[count.index].service_account
 }
 
 module "monitor" {
   source = "../kaia-node"
 
   name         = format("%s-monitor", var.name)
-  machine_type = local.monitor_options.machine_type
+  machine_type = local.monitor_settings.machine_type
 
-  subnetwork    = var.subnetwork
-  zone          = var.zone_list[0]
+  network       = local.monitor_settings.network
+  subnetwork    = local.monitor_settings.subnetwork
+  zone          = local.monitor_settings.zone
   use_public_ip = true
-  region        = var.gcp_region
+  region        = local.monitor_settings.region
   network_tier  = var.network_tier
 
   boot_disk = {
     image_id       = var.boot_image_id
-    boot_disk_size = local.monitor_options.boot_disk_size
+    boot_disk_size = local.monitor_settings.boot_disk_size
   }
 
-  compute_disk = try(local.monitor_options.compute_disk_size, null) != null ? {
+  compute_disk = try(local.monitor_settings.compute_disk_size, null) != null ? {
     name = format("%s-monitor-disk", var.name)
     type = "pd-ssd"
-    zone = var.zone_list[0]
-    size = local.monitor_options.compute_disk_size
-    snapshot = try(local.monitor_options.snapshot_id, null)
+    zone = local.monitor_settings.zone
+    size = local.monitor_settings.compute_disk_size
+    snapshot = try(local.monitor_settings.snapshot_id, null)
   } : null
 
   tags = length(var.network_tags) > 0 ? var.network_tags : ["kaiaspray", "monitor"]

--- a/terraform/gcp/private-layer1/ansible-inventory.tf
+++ b/terraform/gcp/private-layer1/ansible-inventory.tf
@@ -22,6 +22,7 @@ locals {
       kaia_network      = try(var.deploy_options.kaia_network, "")
       kaia_network_id   = try(var.deploy_options.kaia_network_id, "")
       kaia_chain_id     = try(var.deploy_options.kaia_chain_id, "")
+      static_nodes_use_public_ip = try(var.deploy_options.static_nodes_use_public_ip, false)
       homi_extra_options_cn  = try(var.deploy_options.homi_extra_options.cn, "")
       homi_extra_options_pn  = try(var.deploy_options.homi_extra_options.pn, "")
       homi_extra_options_en  = try(var.deploy_options.homi_extra_options.en, "")

--- a/terraform/gcp/private-layer1/templates/groupvarsall.tftpl
+++ b/terraform/gcp/private-layer1/templates/groupvarsall.tftpl
@@ -21,6 +21,7 @@ kaia_num_en: ${kaia_num_en}
 kaia_network: ${kaia_network}
 kaia_network_id: ${kaia_network_id}
 kaia_chain_id: ${kaia_chain_id}
+static_nodes_use_public_ip: ${static_nodes_use_public_ip}
 
 # Node-specific options
 cn_options: ${cn_options}

--- a/terraform/gcp/private-layer1/terraform.tfvars
+++ b/terraform/gcp/private-layer1/terraform.tfvars
@@ -25,6 +25,7 @@ deploy_options = {
   #kaia_network = "kairos"
   kaia_network_id = 9999
   kaia_chain_id   = 9999
+  # static_nodes_use_public_ip = true
   # homi_extra_options = ""
 }
 
@@ -33,6 +34,21 @@ cn_options = {
   machine_type   = "n2-standard-2"
   boot_disk_size = 30
   # compute_disk_size = 100 # if you set compute_disk_size, it will be protected if you delete MANUALLY. So, be aware of this, and please run "destroy" command when you want to delete the node.
+  # spot           = true
+  # options = {
+  #   0 : {
+  #     region      = ""
+  #     subnetwork  = ""
+  #   }
+  #   1 : {
+  #     region     = ""
+  #     subnetwork = ""
+  #   }
+  #   2 : {
+  #     region     = ""
+  #     subnetwork = ""
+  #   }
+  # }
 }
 
 pn_options = {


### PR DESCRIPTION
# Description

* Added per-node region/zone/network/subnetwork overrides for private-layer1 nodes
* Added Spot VM scheduling support (spot, spot_instance_termination_action) in kaia-node
* Wired deploy_options.static_nodes_use_public_ip into Ansible to select public/private KNI in static-nodes
* Fixed homi setup to use loop context values for chainID/network-id (ctx.chain_id, ctx.network_id)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* Public Cloud:
* OS verson:
* Kaia version:
* Ansible version:
* Terraform version:

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
